### PR TITLE
Remove the removal of the eintr checker, which has been removed

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -12,7 +12,6 @@ class BlivetGUILintConfig(PocketLintConfig):
     @property
     def pylintPlugins(self):
         retval = super(BlivetGUILintConfig, self).pylintPlugins
-        retval.remove("pocketlint.checkers.eintr")
         retval.remove("pocketlint.checkers.markup")
         return retval
 


### PR DESCRIPTION
The eintr check has been removed from pocketlint in rawhide since it is no longer relevant in Python 3.5.