### PR TITLE
Allow using btrfs and lvmpv as format for all devices

### DIFF
--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -834,6 +834,8 @@ class AddDialog(Gtk.Dialog):
         supported_fs = supported_filesystems()
         if self.selected_free.size > size.Size("8 MiB"):
             supported_fs.append("lvmpv")
+        if self.selected_free.size > size.Size("256 MiB"):
+            supported_fs.append("btrfs")
 
         for fs in supported_fs:
             self.filesystems_combo.append_text(fs)
@@ -846,7 +848,7 @@ class AddDialog(Gtk.Dialog):
     def on_filesystems_combo_changed(self, combo):
         selection = combo.get_active_text()
 
-        if selection in ("swap", "lmvpv"):
+        if selection in ("swap", "lvmpv", "btrfs"):
             self.hide_widgets(["label", "mountpoint"])
 
         else:
@@ -861,6 +863,8 @@ class AddDialog(Gtk.Dialog):
         dev_min_size = self._get_min_size()
         if selection == "lvmpv":
             self.update_size_area_limits(min_size=max(dev_min_size, size.Size("8 MiB")))
+        elif selection == "btrfs":
+            self.update_size_area_limits(min_size=max(dev_min_size, size.Size("256 MiB")))
         else:
             self.update_size_area_limits(dev_min_size)
 

--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -427,7 +427,6 @@ class AddDialog(Gtk.Dialog):
         self.mountpoints = mountpoints
 
         self.supported_raids = supported_raids()
-        self.supported_fs = supported_filesystems()
 
         Gtk.Dialog.__init__(self, _("Create new device"), None, 0,
                             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OK, Gtk.ResponseType.OK))
@@ -479,7 +478,7 @@ class AddDialog(Gtk.Dialog):
             types.append((_("Partition"), "partition"))
 
             if self.selected_parent.size > size.Size("8 MiB"):
-                types.extend([(_("LVM2 Physical Volume"), "lvmpv"), (_("LVM2 Storage"), "lvm")])
+                types.extend([(_("LVM2 Storage"), "lvm")])
 
             if self.selected_parent.size > size.Size("256 MiB"):
                 types.append((_("Btrfs Volume"), "btrfs volume"))
@@ -490,7 +489,8 @@ class AddDialog(Gtk.Dialog):
         elif self.selected_parent.type == "lvmvg":
             types.extend([(_("LVM2 Logical Volume"), "lvmlv"), (_("LVM2 ThinPool"), "lvmthinpool")])
 
-        elif self.selected_parent.type in ("partition", "luks/dm-crypt", "mdarray") and self.selected_parent.format.type == "lvmpv":
+        elif (self.selected_parent.type in ("partition", "luks/dm-crypt", "mdarray") and
+              self.selected_parent.format.type == "lvmpv" and self.selected_parent.size >= size.Size("8 MiB")):
             types.append((_("LVM2 Volume Group"), "lvmvg"))
 
         elif self.selected_parent.type == "lvmlv":
@@ -647,7 +647,7 @@ class AddDialog(Gtk.Dialog):
 
         if self.selected_type == "lvmvg":
             for ftype, fdevice in self.available_free:
-                if ftype == "lvmpv":
+                if ftype == "lvmpv" and fdevice.size >= size.Size("8 MiB"):
                     self.parents_store.append([fdevice.parents[0], fdevice.size, False, False,
                                                fdevice.parents[0].name, ftype, str(fdevice.size)])
 
@@ -731,7 +731,7 @@ class AddDialog(Gtk.Dialog):
 
         if device_type in ("lvmlv", "lvmthinpool"):
             min_size = max(self.selected_parent.pe_size, size.Size("1 MiB"))
-        elif device_type in ("lvmpv", "lvm"):
+        elif device_type == "lvm":
             min_size = size.Size("8 MiB")
         elif device_type in ("lvmthinlv", "lvm snapshot"):
             min_size = max(self.selected_parent.vg.pe_size, size.Size("1 MiB"))
@@ -821,26 +821,32 @@ class AddDialog(Gtk.Dialog):
         filesystems_combo.set_entry_text_column(0)
         filesystems_combo.set_id_column(0)
 
-        for fs in self.supported_fs:
-            filesystems_combo.append_text(fs)
-
         self.grid.attach(filesystems_combo, 1, 8, 2, 1)
 
-        if "ext4" in self.supported_fs:
-            filesystems_combo.set_active(self.supported_fs.index("ext4"))
-        else:
-            filesystems_combo.set_active(0)
-
         filesystems_combo.connect("changed", self.on_filesystems_combo_changed)
-
         self.widgets_dict["fs"] = [label_fs, filesystems_combo]
 
         return filesystems_combo
 
+    def update_fs_chooser(self):
+        self.filesystems_combo.remove_all()
+
+        supported_fs = supported_filesystems()
+        if self.selected_free.size > size.Size("8 MiB"):
+            supported_fs.append("lvmpv")
+
+        for fs in supported_fs:
+            self.filesystems_combo.append_text(fs)
+
+        if "ext4" in supported_fs:
+            self.filesystems_combo.set_active(supported_fs.index("ext4"))
+        else:
+            self.filesystems_combo.set_active(0)
+
     def on_filesystems_combo_changed(self, combo):
         selection = combo.get_active_text()
 
-        if selection in ("swap",):
+        if selection in ("swap", "lmvpv"):
             self.hide_widgets(["label", "mountpoint"])
 
         else:
@@ -850,6 +856,13 @@ class AddDialog(Gtk.Dialog):
                 self.show_widgets(["label", "mountpoint"])
             else:
                 self.show_widgets(["mountpoint"])
+
+        # TODO: size limits for all formats
+        dev_min_size = self._get_min_size()
+        if selection == "lvmpv":
+            self.update_size_area_limits(min_size=max(dev_min_size, size.Size("8 MiB")))
+        else:
+            self.update_size_area_limits(dev_min_size)
 
     def add_name_chooser(self):
         label_label = Gtk.Label(label=_("Label:"), xalign=1)
@@ -990,6 +1003,7 @@ class AddDialog(Gtk.Dialog):
         device_type = self.selected_type
 
         self.update_parent_list()
+        self.update_fs_chooser()
         self.add_advanced_options()
         self.encrypt_check.set_active(False)
         self.add_size_area()
@@ -997,10 +1011,6 @@ class AddDialog(Gtk.Dialog):
         if device_type == "partition":
             self.show_widgets(["label", "fs", "encrypt", "mountpoint", "size", "advanced"])
             self.hide_widgets(["name", "passphrase", "mdraid"])
-
-        elif device_type == "lvmpv":
-            self.show_widgets(["encrypt", "size"])
-            self.hide_widgets(["name", "label", "fs", "mountpoint", "passphrase", "advanced", "mdraid"])
 
         elif device_type == "lvm":
             self.show_widgets(["encrypt", "name", "size", "advanced"])

--- a/blivetgui/dialogs/edit_dialog.py
+++ b/blivetgui/dialogs/edit_dialog.py
@@ -27,6 +27,8 @@ gi.require_version("Gtk", "3.0")
 
 from gi.repository import Gtk
 
+from blivet.size import Size
+
 from .size_chooser import SizeChooser
 from .helpers import supported_filesystems
 from ..gui_utils import locate_ui_file
@@ -122,6 +124,8 @@ class FormatDialog(object):
         self.fs_combo = self.builder.get_object("comboboxtext_format")
 
         supported_fs = supported_filesystems()
+        if self.edit_device.size > Size("8 MiB"):
+            supported_fs.append("lvmpv")
         for fs in supported_fs:
             self.fs_combo.append_text(fs)
 

--- a/blivetgui/dialogs/helpers.py
+++ b/blivetgui/dialogs/helpers.py
@@ -137,13 +137,11 @@ def supported_filesystems():
     for cls in formats.device_formats.values():
         obj = cls()
 
-        supported_fs = (obj.type not in ("btrfs", "tmpfs") and
+        supported_fs = (obj.type not in ("tmpfs",) and
                         obj.supported and obj.formattable and
                         (isinstance(obj, formats.fs.FS) or
-                         obj.type in ("swap",)))
+                         obj.type in ("swap", "lvmpv")))
         if supported_fs:
-            _fs_types.append(obj.type)
+            _fs_types.append(obj)
 
-    _fs_types.append("unformatted")
-
-    return sorted(_fs_types)
+    return sorted(_fs_types, key=lambda fs: fs.type)

--- a/blivetgui/dialogs/helpers.py
+++ b/blivetgui/dialogs/helpers.py
@@ -142,7 +142,7 @@ def supported_filesystems():
                         (isinstance(obj, formats.fs.FS) or
                          obj.type in ("swap",)))
         if supported_fs:
-            _fs_types.append(obj.name)
+            _fs_types.append(obj.type)
 
     _fs_types.append("unformatted")
 

--- a/data/ui/format_dialog.ui
+++ b/data/ui/format_dialog.ui
@@ -2,6 +2,16 @@
 <!-- Generated with glade 3.19.0 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
+  <object class="GtkListStore" id="liststore_format">
+    <columns>
+      <!-- column-name format -->
+      <column type="PyObject"/>
+      <!-- column-name type -->
+      <column type="gchararray"/>
+      <!-- column-name name -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkDialog" id="format_dialog">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Format device</property>
@@ -75,11 +85,18 @@
               </packing>
             </child>
             <child>
-              <object class="GtkComboBoxText" id="comboboxtext_format">
+              <object class="GtkComboBox" id="combobox_format">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">start</property>
-                <property name="margin_top">4</property>
+                <property name="model">liststore_format</property>
+                <property name="entry_text_column">2</property>
+                <property name="id_column">1</property>
+                <child>
+                  <object class="GtkCellRendererText" id="cellrenderertext1"/>
+                  <attributes>
+                    <attribute name="text">2</attribute>
+                  </attributes>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -316,7 +316,7 @@ class AddDialogTest(unittest.TestCase):
 
         types = sorted([i[1] for i in add_dialog.devices_combo.get_model()])
 
-        self.assertTrue(sorted(["partition", "lvm", "lvmpv", "btrfs volume", "mdraid"]) == types)
+        self.assertTrue(sorted(["partition", "lvm", "btrfs volume", "mdraid"]) == types)
         self.assertTrue(add_dialog.devices_combo.get_sensitive())
 
         # disk with disklabel and not enough free space, no other disks available
@@ -328,7 +328,7 @@ class AddDialogTest(unittest.TestCase):
 
         types = sorted([i[1] for i in add_dialog.devices_combo.get_model()])
 
-        self.assertTrue(sorted(["partition", "lvm", "lvmpv"]) == types)
+        self.assertTrue(sorted(["partition", "lvm"]) == types)
         self.assertTrue(add_dialog.devices_combo.get_sensitive())
 
         # lvmpv
@@ -378,25 +378,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertTrue(add_dialog.encrypt_check.get_visible())
         self.assertFalse(add_dialog.raid_combo.get_visible())
         self.assertIsNotNone(add_dialog.advanced)
-        self.assertFalse(add_dialog.md_type_combo.get_visible())
-        self.assertTrue(add_dialog.size_area.get_sensitive())
-
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
-    def test_lvmpv_widgets(self):
-        parent_device = self._get_parent_device()
-        free_device = self._get_free_device(parent=parent_device)
-
-        add_dialog = AddDialog(self.parent_window, parent_device, free_device,
-                               [("free", free_device)], [])
-
-        add_dialog.devices_combo.set_active_id("lvmpv")
-        self.assertEqual(add_dialog.selected_type, "lvmpv")
-
-        self.assertFalse(add_dialog.filesystems_combo.get_visible())
-        self.assertFalse(add_dialog.name_entry.get_visible())
-        self.assertTrue(add_dialog.encrypt_check.get_visible())
-        self.assertFalse(add_dialog.raid_combo.get_visible())
-        self.assertIsNone(add_dialog.advanced)
         self.assertFalse(add_dialog.md_type_combo.get_visible())
         self.assertTrue(add_dialog.size_area.get_sensitive())
 
@@ -557,13 +538,13 @@ class AddDialogTest(unittest.TestCase):
                                [("free", free_device)], [], True)  # with kickstart_mode=True
 
         # swap -- mountpoint and label entries shouldn't be visible
-        add_dialog.filesystems_combo.set_active(add_dialog.supported_fs.index("swap"))
+        add_dialog.filesystems_combo.set_active_id("swap")
         self.assertEqual(add_dialog.filesystems_combo.get_active_text(), "swap")
         self.assertFalse(add_dialog.mountpoint_entry.get_visible())
         self.assertFalse(add_dialog.label_entry.get_visible())
 
         # ext4 -- mountpoint and label entries should be visible
-        add_dialog.filesystems_combo.set_active(add_dialog.supported_fs.index("ext4"))
+        add_dialog.filesystems_combo.set_active_id("ext4")
         self.assertEqual(add_dialog.filesystems_combo.get_active_text(), "ext4")
         self.assertTrue(add_dialog.mountpoint_entry.get_visible())
         self.assertTrue(add_dialog.label_entry.get_visible())

--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -539,13 +539,13 @@ class AddDialogTest(unittest.TestCase):
 
         # swap -- mountpoint and label entries shouldn't be visible
         add_dialog.filesystems_combo.set_active_id("swap")
-        self.assertEqual(add_dialog.filesystems_combo.get_active_text(), "swap")
+        self.assertEqual(add_dialog.filesystems_combo.get_active_id(), "swap")
         self.assertFalse(add_dialog.mountpoint_entry.get_visible())
         self.assertFalse(add_dialog.label_entry.get_visible())
 
         # ext4 -- mountpoint and label entries should be visible
         add_dialog.filesystems_combo.set_active_id("ext4")
-        self.assertEqual(add_dialog.filesystems_combo.get_active_text(), "ext4")
+        self.assertEqual(add_dialog.filesystems_combo.get_active_id(), "ext4")
         self.assertTrue(add_dialog.mountpoint_entry.get_visible())
         self.assertTrue(add_dialog.label_entry.get_visible())
 


### PR DESCRIPTION
Remove special "type" for adding lvmpv and allow using lvmpv as a format for all devices.
Same applies for btrfs, but "btrfs volume" can be still added to allow adding btrfs volume with multiple (non-existing) parents.