### PR TITLE
Add custom exception handler for blivet-gui

### DIFF
--- a/blivetgui/dialogs/constants.py
+++ b/blivetgui/dialogs/constants.py
@@ -1,0 +1,5 @@
+
+class DialogResponseType(object):
+    BACK = 1
+    REPORT = 2
+    QUIT = 3

--- a/blivetgui/exception_handler.py
+++ b/blivetgui/exception_handler.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+# exception_handler.py
+# Custom exception handler for blivet-gui
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+#
+# ---------------------------------------------------------------------------- #
+
+import subprocess
+import sys
+import traceback
+
+import gi
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gtk
+
+from .dialogs import message_dialogs, constants
+from .gui_utils import command_exists
+from .i18n import _
+
+# ---------------------------------------------------------------------------- #
+
+
+class BlivetGUIExceptionHandler(object):
+
+    allow_ignore = False
+
+    def __init__(self, main_window, excepthook):
+        self.main_window = main_window
+        self.excepthook = excepthook
+
+    def handle_exception(self, exc_type, exc_value, exc_traceback):
+
+        tr = "".join(traceback.format_tb(exc_traceback))
+        if self.allow_ignore:
+            msg = _("Unknown error occured.\n{error}").format(error=str(exc_value))
+        else:
+            msg = _("Unknown error occured. Blivet-gui will be terminated.\n{error}").format(error=str(exc_value))
+
+        allow_report = command_exists("gnome-abrt")
+
+        dialog = message_dialogs.ExceptionDialog(self.main_window, self.allow_ignore,
+                                                 allow_report, msg, tr)
+        response = dialog.run()
+
+        if response == constants.DialogResponseType.BACK:
+            return
+        else:
+            # restore handler and re-raise original exception
+            sys.excepthook = self.excepthook
+            sys.excepthook(exc_type, exc_value, exc_traceback)
+
+            if response == constants.DialogResponseType.REPORT:
+                subprocess.call(["gnome-abrt"])
+
+            Gtk.main_quit()

--- a/blivetgui/gui_utils.py
+++ b/blivetgui/gui_utils.py
@@ -23,8 +23,17 @@
 # ---------------------------------------------------------------------------- #
 
 import os
+import shutil
 
 # ---------------------------------------------------------------------------- #
+
+
+def command_exists(command):
+    """ Find if given command exists
+    """
+
+    ret = shutil.which(command)
+    return bool(ret)
 
 
 def locate_ui_file(filename):

--- a/data/ui/exception_dialog.ui
+++ b/data/ui/exception_dialog.ui
@@ -8,28 +8,59 @@
     <property name="type_hint">dialog</property>
     <property name="deletable">False</property>
     <property name="message_type">error</property>
-    <property name="buttons">ok</property>
     <property name="text" translatable="yes">Error</property>
     <child internal-child="vbox">
-      <object class="GtkBox" id="messagedialog-vbox">
+      <object class="GtkBox">
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="messagedialog-action_area">
+          <object class="GtkButtonBox">
             <property name="can_focus">False</property>
             <property name="layout_style">expand</property>
             <child>
-              <placeholder/>
+              <object class="GtkButton" id="button_back">
+                <property name="label" translatable="yes">Back</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkButton" id="button_report">
+                <property name="label" translatable="yes">Report a bug</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_quit">
+                <property name="label" translatable="yes">Quit</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="fill">False</property>
             <property name="position">0</property>
           </packing>
         </child>


### PR DESCRIPTION
With recent remove of python-meh support, blivet-gui needs some
basic exception handler that would show the error and quit the
GUI. System exception handler (ABRT) is restored for automatic
reporting.