### PR TITLE
Add support for setting mountpoints

### DIFF
--- a/blivetgui/actions_menu.py
+++ b/blivetgui/actions_menu.py
@@ -46,7 +46,8 @@ class ActionsMenu(object):
                  ("unmount", self.blivet_gui.umount_partition),
                  ("decrypt", self.blivet_gui.decrypt_device),
                  ("info", self.blivet_gui.device_information),
-                 ("parents", self.blivet_gui.edit_lvmvg)]
+                 ("parents", self.blivet_gui.edit_lvmvg),
+                 ("mountpoint", self.blivet_gui.set_mountpoint)]
 
         for item in items:
             menu_item = self.blivet_gui.builder.get_object("menuitem_" + item[0])

--- a/blivetgui/actions_toolbar.py
+++ b/blivetgui/actions_toolbar.py
@@ -68,7 +68,8 @@ class DeviceToolbar(BlivetGUIToolbar):
                  ("unmount", "clicked", self.blivet_gui.umount_partition),
                  ("decrypt", "clicked", self.blivet_gui.decrypt_device),
                  ("info", "clicked", self.blivet_gui.device_information),
-                 ("parents", "activate", self.blivet_gui.edit_lvmvg)]
+                 ("parents", "activate", self.blivet_gui.edit_lvmvg),
+                 ("mountpoint", "activate", self.blivet_gui.set_mountpoint)]
 
         for item in items:
             menu_item = self.blivet_gui.builder.get_object("button_" + item[0])

--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -268,7 +268,15 @@ class BlivetGUI(object):
     def format_device(self, _widget=None):
         device = self.list_partitions.selected_partition[0]
 
-        dialog = edit_dialog.FormatDialog(self.main_window, device)
+        if self.installer_mode:
+            mountpoints = self.client.remote_call("get_mountpoints")
+        else:
+            mountpoints = []
+
+        dialog = edit_dialog.FormatDialog(main_window=self.main_window,
+                                          edit_device=device,
+                                          mountpoints=mountpoints,
+                                          installer_mode=self.installer_mode)
 
         user_input = self.run_dialog(dialog)
         if user_input.format:

--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -469,6 +469,29 @@ class BlivetGUI(object):
             self.update_partitions_view()
             self.list_devices.update_devices_view()
 
+    def set_mountpoint(self, _widget=None):
+        device = self.list_partitions.selected_partition[0]
+
+        if not device.format.mountable:
+            raise RuntimeError("Format (%s) of selected device (%s) "
+                               "is not mountable." % (device.format.type, device.name))
+
+        if self.installer_mode:
+            mountpoints = self.client.remote_call("get_mountpoints")
+        else:
+            mountpoints = []
+
+        dialog = edit_dialog.MountpointDialog(main_window=self.main_window,
+                                              edit_device=device,
+                                              mountpoints=mountpoints,
+                                              installer_mode=self.installer_mode)
+
+        user_input = self.run_dialog(dialog)
+
+        if user_input.do_set:
+            device.format.mountpoint = user_input.mountpoint
+            self.update_partitions_view()
+
     def perform_actions(self, dialog):
         """ Perform queued actions
         """

--- a/blivetgui/list_partitions.py
+++ b/blivetgui/list_partitions.py
@@ -195,6 +195,12 @@ class ListPartitions(object):
 
         return not device.format.status
 
+    def _allow_set_mountpoint(self, device):
+        if not self.blivet_gui.installer_mode:
+            return False
+
+        return device.format.mountable
+
     def _allow_add_device(self, device):
         if device.protected:
             return False
@@ -236,6 +242,9 @@ class ListPartitions(object):
 
         if self._allow_add_device(device):
             self.blivet_gui.activate_device_actions(["add"])
+
+        if self._allow_set_mountpoint(device):
+            self.blivet_gui.activate_device_actions(["mountpoint"])
 
         if device.type == "lvmvg":
             self.blivet_gui.activate_device_actions(["parents"])

--- a/data/ui/blivet-gui.ui
+++ b/data/ui/blivet-gui.ui
@@ -59,6 +59,14 @@
                 <property name="use_underline">True</property>
               </object>
             </child>
+            <child>
+              <object class="GtkMenuItem" id="menuitem_mountpoint">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Set mountpoint</property>
+                <property name="use_underline">True</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>
@@ -112,6 +120,14 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="label" translatable="yes">Modify parents</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="button_mountpoint">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Set mountpoint</property>
         <property name="use_underline">True</property>
       </object>
     </child>

--- a/data/ui/format_dialog.ui
+++ b/data/ui/format_dialog.ui
@@ -21,6 +21,10 @@
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox">
         <property name="can_focus">False</property>
+        <property name="margin_left">6</property>
+        <property name="margin_right">6</property>
+        <property name="margin_top">6</property>
+        <property name="margin_bottom">6</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
@@ -76,7 +80,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="box">
+          <object class="GtkBox" id="box_format">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="margin_left">12</property>
@@ -123,6 +127,44 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box_mountpoint">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_top">8</property>
+            <property name="margin_bottom">8</property>
+            <property name="homogeneous">True</property>
+            <child>
+              <object class="GtkLabel" id="label_mountpoint">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Enter new mountpoint:</property>
+                <property name="justify">center</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="entry_mountpoint">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/data/ui/mountpoint_dialog.ui
+++ b/data/ui/mountpoint_dialog.ui
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.16"/>
+  <object class="GtkDialog" id="mountpoint_dialog">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Set mountpoint</property>
+    <property name="window_position">center</property>
+    <property name="type_hint">dialog</property>
+    <property name="gravity">center</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox">
+        <property name="can_focus">False</property>
+        <property name="margin_left">6</property>
+        <property name="margin_right">6</property>
+        <property name="margin_top">6</property>
+        <property name="margin_bottom">6</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button_cancel">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="yalign">0.62000000476837158</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button_set">
+                <property name="label" translatable="yes" context="Dialog|Format" comments="Perform selected format change on this device.">Set mountpoint</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label_title">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box_mountpoint">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_top">8</property>
+            <property name="margin_bottom">8</property>
+            <property name="homogeneous">True</property>
+            <child>
+              <object class="GtkLabel" id="label_mountpoint">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Enter new mountpoint:</property>
+                <property name="justify">center</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="entry_mountpoint">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -274,10 +274,7 @@ class AdvancedOptionsTest(unittest.TestCase):
 class AddDialogTest(unittest.TestCase):
 
     error_dialog = MagicMock()
-
-    @classmethod
-    def setUpClass(cls):
-        cls.parent_window = MagicMock(spec=Gtk.Window)
+    parent_window = Gtk.Window()
 
     def _get_free_device(self, size=Size("8 GiB"), logical=False, parent=None, **kwargs):
         if not parent:
@@ -307,7 +304,6 @@ class AddDialogTest(unittest.TestCase):
 
         return dev
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_allowed_device_types(self):
         # disk with disklabel and enough free space, other disks available
         parent_device = self._get_parent_device()
@@ -345,7 +341,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertTrue(sorted(["lvmvg"]) == types)
         self.assertFalse(add_dialog.devices_combo.get_sensitive())
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_partition_widgets(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -364,7 +359,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertFalse(add_dialog.md_type_combo.get_visible())
         self.assertTrue(add_dialog.size_area.get_sensitive())
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_lvm_widgets(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -383,7 +377,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertFalse(add_dialog.md_type_combo.get_visible())
         self.assertTrue(add_dialog.size_area.get_sensitive())
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_btrfsvolume_widgets(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -402,7 +395,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertFalse(add_dialog.md_type_combo.get_visible())
         self.assertTrue(add_dialog.size_area.get_sensitive())
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_mdraid_widgets(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -419,7 +411,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertIsNotNone(add_dialog.advanced)
         self.assertTrue(add_dialog.md_type_combo.get_visible())
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_partition_parents(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -436,7 +427,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertTrue(add_dialog.parents_store[0][3])
         self.assertEqual(add_dialog.parents_store[0][5], "disk")
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_lvm_parents(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -453,7 +443,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertFalse(add_dialog.parents_store[1][2])  # other two free devices shouldn't be selected
         self.assertFalse(add_dialog.parents_store[2][2])
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_lvmlv_parents(self):
         parent_device = self._get_parent_device(dtype="lvmvg", ftype=None)
         free_device = self._get_free_device(parent=parent_device)
@@ -470,7 +459,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertTrue(add_dialog.parents_store[0][3])
         self.assertEqual(add_dialog.parents_store[0][5], "lvmvg")
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_btrfs_parents(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -486,7 +474,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertTrue(add_dialog.parents_store[0][2])
         self.assertFalse(add_dialog.parents_store[1][2])  # other free device shouldn't be selected
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_parents_update(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -502,7 +489,6 @@ class AddDialogTest(unittest.TestCase):
         add_dialog.devices_combo.set_active_id("lvm")
         self.assertEqual(len(add_dialog.parents_store), 3)
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_parents_selection(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -531,7 +517,6 @@ class AddDialogTest(unittest.TestCase):
 
         self.assertFalse(add_dialog.parents_store[1][3])
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_fs_chooser(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -551,7 +536,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertTrue(add_dialog.mountpoint_entry.get_visible())
         self.assertTrue(add_dialog.label_entry.get_visible())
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_encrypt_check(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -572,7 +556,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertFalse(add_dialog.pass2_entry.get_visible())
         self.assertEqual(add_dialog.size_area.min_size, min_size)
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_passphrase_entry(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -591,7 +574,6 @@ class AddDialogTest(unittest.TestCase):
         add_dialog.pass2_entry.set_text("aa")
         self.assertEqual(add_dialog.pass2_entry.get_icon_name(Gtk.EntryIconPosition.SECONDARY), "emblem-ok-symbolic.symbolic")
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_md_type(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -608,7 +590,6 @@ class AddDialogTest(unittest.TestCase):
         add_dialog.md_type_combo.set_active_id("lvmpv")
         self.assertFalse(add_dialog.filesystems_combo.get_visible())
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_raid_type(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device, size=Size("8 GiB"))
@@ -634,7 +615,6 @@ class AddDialogTest(unittest.TestCase):
         # raid1 type is selected --> we should have 2 size areas, both with max size 4 GiB (smaller free space size)
         self.assertEqual(add_dialog.size_area.max_size, Size("4 GiB"))
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
     def test_encrypt_validity_check(self):
         parent_device = self._get_parent_device()
@@ -666,7 +646,6 @@ class AddDialogTest(unittest.TestCase):
         self.error_dialog.assert_any_call(add_dialog, _("Passphrase not specified."), True)
         self.error_dialog.reset_mock()
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
     def test_mountpoint_validity_check(self):
         parent_device = self._get_parent_device()
@@ -698,7 +677,6 @@ class AddDialogTest(unittest.TestCase):
         self.error_dialog.assert_any_call(add_dialog, _("Selected mountpoint \"{0}\" is already set for another device.").format(mnt), False)
         self.error_dialog.reset_mock()
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
     @unittest.skip("name validity check temporarily disabled")
     def test_name_validity_check(self):
@@ -724,7 +702,6 @@ class AddDialogTest(unittest.TestCase):
         self.error_dialog.assert_any_call(add_dialog, _("\"{0}\" is not a valid name.").format(name), True)
         self.error_dialog.reset_mock()
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
     def test_label_validity_check(self):
         parent_device = self._get_parent_device()
@@ -747,10 +724,9 @@ class AddDialogTest(unittest.TestCase):
         label = "a" * 50
         add_dialog.label_entry.set_text(label)
         add_dialog.validate_user_input()
-        self.error_dialog.assert_any_call(add_dialog, "\"%s\" is not a valid label." % label, True)
+        self.error_dialog.assert_any_call(add_dialog, _("\"{0}\" is not a valid label.").format(label), True)
         self.error_dialog.reset_mock()
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_partition_selection(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device)
@@ -788,7 +764,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertEqual(selection.parents, [(parent_device, size)])
         self.assertIsNone(selection.raid_level)
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_lvm_selection(self):
         parent_device1 = self._get_parent_device()
         parent_device2 = self._get_parent_device()
@@ -824,7 +799,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertTrue(selection.passphrase in (None, ""))
         self.assertIsNone(selection.raid_level)
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_md_selection(self):
         parent_device1 = self._get_parent_device()
         parent_device2 = self._get_parent_device()
@@ -871,7 +845,6 @@ class AddDialogTest(unittest.TestCase):
         self.assertEqual(selection.parents, [(parent_device1, size), (parent_device2, size)])
         self.assertEqual(selection.raid_level, "raid0")
 
-    @patch("blivetgui.dialogs.add_dialog.AddDialog.set_transient_for", lambda dialog, window: True)
     def test_btrfs_selection(self):
         parent_device = self._get_parent_device()
         free_device = self._get_free_device(parent=parent_device, size=Size("8 GiB"), is_free_region=False,

--- a/tests/blivetgui_tests/edit_dialog_test.py
+++ b/tests/blivetgui_tests/edit_dialog_test.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+import gi
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gtk
+
+from blivet.size import Size
+
+from blivetgui.dialogs.edit_dialog import FormatDialog
+from blivetgui.dialogs.helpers import supported_filesystems
+from blivetgui.i18n import _
+
+
+@unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
+class FormatDialogTest(unittest.TestCase):
+
+    error_dialog = MagicMock()
+    parent_window = Gtk.Window()
+
+    def test_basic(self):
+
+        dev = MagicMock(size=Size("1 GiB"))
+        dialog = FormatDialog(self.parent_window, dev, [], False)
+
+        # not installer_mode, mountpoint widgets should be invisible
+        self.assertFalse(dialog.mnt_box.get_visible())
+
+        # test filesystem selection
+        fstype = next((fs.type for fs in supported_filesystems()), None)
+        if fstype:
+            dialog.fs_combo.set_active_id(fstype)
+            selected_fs, selected_mnt = dialog.get_selection()
+            self.assertEqual(selected_fs, fstype)
+            self.assertIsNone(selected_mnt)
+
+        # test 'unformatted' selection
+        dialog.fs_combo.set_active_id("unformatted")
+        selected_fs, selected_mnt = dialog.get_selection()
+        self.assertIsNone(selected_fs)
+        self.assertIsNone(selected_mnt)
+
+    @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
+    def test_installer(self):
+        dev = MagicMock(size=Size("1 GiB"))
+
+        dialog = FormatDialog(self.parent_window, dev, [], True)
+
+        # ninstaller_mode, mountpoint widgets should be visible
+        self.assertTrue(dialog.mnt_entry.get_visible())
+
+        # test mountpoint entry sensitivity (insensitive for not mountable) and selection
+        fstype = next((fs.type for fs in supported_filesystems() if fs.mountable), None)
+        if fstype:
+            dialog.fs_combo.set_active_id(fstype)
+            dialog.mnt_entry.set_text("/boot")
+
+            selected_fs, selected_mnt = dialog.get_selection()
+            self.assertTrue(dialog.mnt_entry.get_sensitive())
+            self.assertEqual(selected_fs, fstype)
+            self.assertEqual(selected_mnt, "/boot")
+
+        # test 'unformatted' selection (can't set mountpoint for "none" format)
+        dialog.fs_combo.set_active_id("unformatted")
+        selected_fs, selected_mnt = dialog.get_selection()
+        self.assertFalse(dialog.mnt_entry.get_sensitive())
+
+        # test mountpoint validation
+        fstype = next((fs.type for fs in supported_filesystems() if fs.mountable), None)
+        if fstype:
+            dialog.fs_combo.set_active_id(fstype)
+            dialog.mnt_entry.set_text("aaaaa")
+            dialog.validate_user_input()
+            self.error_dialog.assert_any_call(dialog.dialog,
+                                              _("\"{0}\" is not a valid mountpoint.").format("aaaaa"),
+                                              False)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add support for setting mountpoints in installer mode both with and without reformatting the device.

Third commit (_Use Gtk.Window in AddDialogTest instead of Mock_) is not related to this. I just realized this could be done in a better way when writing test for the `FormatDialog`.