### PR TITLE
AddDialog and SizeArea changes

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -24,7 +24,7 @@
 import blivet
 
 from blivet.devices import PartitionDevice, LUKSDevice, LVMVolumeGroupDevice, BTRFSVolumeDevice, BTRFSSubVolumeDevice, MDRaidArrayDevice
-from blivet.devices.lvm import LVMCacheRequest, LVPVSpec
+from blivet.devices.lvm import LVPVSpec
 from blivet.formats import DeviceFormat
 
 from blivet.devicelibs.crypto import LUKS_METADATA_SIZE
@@ -835,20 +835,12 @@ class BlivetUtils(object):
         vg_device = user_input.size_selection.parents[0].parent_device.children[0]
         device_name = self._pick_device_name(user_input.name, vg_device)
 
-        if user_input.advanced.cache:
-            cache_request = LVMCacheRequest(size=user_input.advanced.size,
-                                            pvs=user_input.advanced.parents,
-                                            mode=user_input.advanced.type)
-        else:
-            cache_request = None
-
         # no LVPVSpec for linear LVs
         if user_input.raid_level in ("linear", None):
             new_part = self.storage.new_lv(name=device_name,
                                            size=user_input.size_selection.total_size,
                                            parents=[vg_device],
-                                           seg_type=user_input.raid_level,
-                                           cache_request=cache_request)
+                                           seg_type=user_input.raid_level)
 
         else:
             pvs = [LVPVSpec(parent.parent_device, None) for parent in user_input.size_selection.parents]
@@ -856,8 +848,7 @@ class BlivetUtils(object):
                                            size=user_input.size_selection.total_size,
                                            parents=[vg_device],
                                            pvs=pvs,
-                                           seg_type=user_input.raid_level,
-                                           cache_request=cache_request)
+                                           seg_type=user_input.raid_level)
 
         actions.append(blivet.deviceaction.ActionCreateDevice(new_part))
 

--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -428,7 +428,8 @@ class BlivetGUI(object):
 
             else:
                 if result.actions:
-                    action_str = _("add {size} {type} device").format(size=str(user_input.size), type=user_input.device_type)
+                    action_str = _("add {size} {type} device").format(size=str(user_input.size_selection.total_size),
+                                                                      type=user_input.device_type)
 
                     self.list_actions.append("add", action_str, result.actions)
 

--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -1181,10 +1181,8 @@ class AddDialog(Gtk.Dialog):
             parents = size_selection
             pvs = None
 
-        if device_type in ("btrfs volume", "mdraid"):
+        if device_type in ("btrfs volume", "mdraid", "lvmlv"):
             raid_level = self._raid_chooser.selected_level.name
-        elif device_type == "lvmlv":
-            raid_level = self.size_area.parent_area.raid_chooser.selected
         else:
             raid_level = None
 

--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -499,7 +499,7 @@ class AddDialog(Gtk.Dialog):
         elif self.selected_type in ("btrfs volume", "lvm", "mdraid"):
             for ftype, fdevice in self.available_free:
                 if ftype == "free":
-                    if self.selected_type == "btrfs volume" and fdevice.size < size.Size("256 MiB"):
+                    if self.selected_type == "btrfs volume" and fdevice.size < BTRFS._min_size:
                         # too small for new btrfs
                         continue
 

--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -358,10 +358,10 @@ class AddDialog(Gtk.Dialog):
         if self.selected_parent.type in ("disk", "mdarray"):
             types.append((_("Partition"), "partition"))
 
-            if self.selected_parent.size > lvm.LVM_PE_SIZE * 2:
+            if self.selected_free.size > lvm.LVM_PE_SIZE * 2:
                 types.extend([(_("LVM2 Volume Group"), "lvm")])
 
-            if self.selected_parent.size > size.Size("256 MiB"):
+            if self.selected_free.size > BTRFS._min_size:
                 types.append((_("Btrfs Volume"), "btrfs volume"))
 
             if len([f[0] for f in self.available_free if f[0] == "free"]) > 1:  # number of free disk regions

--- a/blivetgui/dialogs/widgets.py
+++ b/blivetgui/dialogs/widgets.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+# widgets.py
+# GUI widgets for dialogs (mainly for AddDialog)
+#
+# Copyright (C) 2014  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+#
+# ---------------------------------------------------------------------------- #
+
+import gi
+gi.require_version("Gtk", "3.0")
+
+from gi.repository import Gtk
+from contextlib import contextmanager
+
+from blivet.devicelibs.raid import RAID0, Single, Linear
+
+from .helpers import supported_raids
+from ..gui_utils import locate_ui_file
+
+
+class GUIWidget(object):
+    """ Helper class for 'composite' widgets for blivet-gui that reads given
+        Glade file and implements some usefull Gtk.Widget methods
+    """
+
+    name = None
+    glade_file = None
+
+    def __init__(self, glade_file):
+
+        self._builder = Gtk.Builder()
+        self._builder.set_translation_domain("blivet-gui")
+        self._builder.add_from_file(locate_ui_file(glade_file))
+
+        # the glade file has to have either box or grid as a top level widget
+        self.box = self._builder.get_object("box") or self._builder.get_object("grid")
+
+        # get list of all 'real' widgets in this widget
+        self.widgets = self._builder.get_objects()
+
+    @contextmanager
+    def block_handlers(self, widget, handlers):
+        for handler_id in handlers:
+            widget.handler_block(handler_id)
+
+        yield
+
+        for handler_id in handlers:
+            widget.handler_unblock(handler_id)
+
+    def connect(self, signal_name, signal_handler, *args):
+        raise NotImplementedError
+
+    def destroy(self):
+        """ Destroy this widgets """
+
+        for widget in self.widgets:
+            widget.hide()
+            widget.destroy()
+
+    def show(self):
+        """ Show this widget """
+
+        self.set_visible(True)
+
+    def hide(self):
+        """ Hide this widget """
+
+        self.set_visible(False)
+
+    def set_visible(self, visibility):
+        """ Hide/show this widget
+
+            :param visibility: visibility
+            :type visibility: bool
+
+        """
+
+        for widget in self.widgets:
+            if hasattr(widget, "set_visible"):
+                # 'non-gui' widgets like treestores are in glade file but don't
+                # have visibility, sensitivity etc. methods
+                widget.set_visible(visibility)
+
+    def get_visible(self):
+        return all([widget.get_visible() for widget in self.widgets if hasattr(widget, "get_visible")])
+
+    def set_sensitive(self, sensitivity):
+        """ Set sensitivity for this widget
+
+            :param sensitivity: sensitivity
+            :type sensitivity: bool
+
+        """
+        for widget in self.widgets:
+            if hasattr(widget, "set_sensitive"):
+                # 'non-gui' widgets like treestores are in glade file but don't
+                # have visibility, sensitivity etc. methods
+                widget.set_sensitive(sensitivity)
+
+    def get_sensitive(self):
+        return all([widget.get_sensitive() for widget in self.widgets if hasattr(widget, "get_sensitive")])
+
+
+class RaidChooser(GUIWidget):
+
+    glade_file = "raid_chooser.ui"
+    name = "raid chooser"
+    supported_signals = ("changed",)
+
+    def __init__(self):
+
+        super().__init__()
+
+        self.supported_raids = supported_raids()
+
+        self._combobox_raid = self._builder.get_object("combobox_raid")
+        self._liststore_raid = self._builder.get_object("liststore_raid")
+
+        self._handler_ids = []
+
+    @property
+    def selected_level(self):
+        treeiter = self._combobox_raid.get_active_iter()
+
+        if treeiter:
+            return self._liststore_raid[treeiter][1]
+
+    @selected_level.setter
+    def selected_level(self, raid_level):
+        for idx, raid in enumerate(self._liststore_raid):
+            if raid[1] == raid_level:
+                self._combobox_raid.set_active(idx)
+                return
+
+        # selected raid type not found
+        raise ValueError("RAID type %s is not available for selection." % raid_level)
+
+    def connect(self, signal_name, signal_handler, *args):
+        if signal_name not in self.supported_signals:
+            raise ValueError("Widget %s doesn't support signal %s" % (self.name, signal_name))
+
+        handler_id = self._combobox_raid.connect(signal_name, signal_handler, *args)
+        self._handler_ids.append(handler_id)
+
+        return handler_id
+
+    def update(self, device_type, num_parents):
+        """ Update list of available raid levels based on currently selected device """
+
+        # block all currently connected signal handlers -- changing the liststore
+        # results in emitting 'changed' signal for every added/removed raid level
+        with self.block_handlers(self._combobox_raid, self._handler_ids):
+            self._liststore_raid.clear()
+
+            try:
+                levels = self.supported_raids[device_type]
+            except KeyError:
+                levels = []
+
+            for raid in levels:
+                if num_parents >= raid.min_members:
+                    self._liststore_raid.append((raid.name, raid))
+
+        if len(self._liststore_raid) == 0:
+            self.set_visible(False)
+            self.set_sensitive(False)
+        elif len(self._liststore_raid) > 1:
+            self.set_visible(True)
+            self.set_sensitive(True)
+        else:
+            self.set_visible(True)
+            self.set_sensitive(False)
+
+    def autoselect(self, device_type):
+        """ Automatically select some 'sane' level for given device type """
+
+        if device_type == "lvmlv":
+            default_level = Linear
+        elif device_type == "btrfs volume":
+            default_level = Single
+        elif device_type == "mdraid":
+            default_level = RAID0
+        else:
+            default_level = None
+
+        try:
+            self.selected_level = default_level
+        except ValueError:
+            # default level not supported so just select first one in the list
+            treeiter = self._liststore_raid.get_iter_first()
+
+            if treeiter:
+                self._combobox_raid.set_active_iter(treeiter)

--- a/blivetgui/dialogs/widgets.py
+++ b/blivetgui/dialogs/widgets.py
@@ -42,11 +42,11 @@ class GUIWidget(object):
     name = None
     glade_file = None
 
-    def __init__(self, glade_file):
+    def __init__(self):
 
         self._builder = Gtk.Builder()
         self._builder.set_translation_domain("blivet-gui")
-        self._builder.add_from_file(locate_ui_file(glade_file))
+        self._builder.add_from_file(locate_ui_file(self.glade_file))
 
         # the glade file has to have either box or grid as a top level widget
         self.box = self._builder.get_object("box") or self._builder.get_object("grid")

--- a/blivetgui/dialogs/widgets.py
+++ b/blivetgui/dialogs/widgets.py
@@ -130,6 +130,9 @@ class RaidChooser(GUIWidget):
 
         self.supported_raids = supported_raids()
 
+        # temporarily disable LVM RAID
+        self.supported_raids["lvmlv"] = [Linear]
+
         self._combobox_raid = self._builder.get_object("combobox_raid")
         self._liststore_raid = self._builder.get_object("liststore_raid")
 

--- a/data/ui/raid_chooser.ui
+++ b/data/ui/raid_chooser.ui
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.19.0 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
   <object class="GtkListStore" id="liststore_raid">
@@ -13,11 +12,16 @@
   <object class="GtkBox" id="box">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
+    <property name="halign">center</property>
+    <property name="spacing">8</property>
     <child>
       <object class="GtkLabel" id="label_raid">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="label" translatable="yes">RAID level:</property>
+        <style>
+          <class name="dim-label"/>
+        </style>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -360,7 +360,7 @@ class AddDialogTest(unittest.TestCase):
         self.assertTrue(add_dialog.filesystems_combo.get_visible())
         self.assertFalse(add_dialog.name_entry.get_visible())
         self.assertTrue(add_dialog.encrypt_check.get_visible())
-        self.assertFalse(add_dialog.raid_combo.get_visible())
+        self.assertFalse(add_dialog._raid_chooser.get_visible())
         self.assertIsNotNone(add_dialog.advanced)
         self.assertFalse(add_dialog.md_type_combo.get_visible())
         self.assertTrue(add_dialog.size_area.get_sensitive())
@@ -378,7 +378,7 @@ class AddDialogTest(unittest.TestCase):
         self.assertFalse(add_dialog.filesystems_combo.get_visible())
         self.assertTrue(add_dialog.name_entry.get_visible())
         self.assertTrue(add_dialog.encrypt_check.get_visible())
-        self.assertFalse(add_dialog.raid_combo.get_visible())
+        self.assertFalse(add_dialog._raid_chooser.get_visible())
         self.assertIsNotNone(add_dialog.advanced)
         self.assertFalse(add_dialog.md_type_combo.get_visible())
         self.assertTrue(add_dialog.size_area.get_sensitive())
@@ -396,7 +396,7 @@ class AddDialogTest(unittest.TestCase):
         self.assertFalse(add_dialog.filesystems_combo.get_visible())
         self.assertTrue(add_dialog.name_entry.get_visible())
         self.assertFalse(add_dialog.encrypt_check.get_visible())
-        self.assertFalse(add_dialog.raid_combo.get_visible())
+        self.assertTrue(add_dialog._raid_chooser.get_visible())
         self.assertIsNone(add_dialog.advanced)
         self.assertFalse(add_dialog.md_type_combo.get_visible())
         self.assertTrue(add_dialog.size_area.get_sensitive())
@@ -606,17 +606,11 @@ class AddDialogTest(unittest.TestCase):
         # select second parent --> raid combo should be visible
         add_dialog.on_cell_toggled(None, 1)
         add_dialog.parents_store[1][2] = True
-        self.assertTrue(add_dialog.raid_combo.get_visible())
-        self.assertEqual(add_dialog.raid_combo.get_active_id(), "linear")  # linear is default value for mdraid
+        self.assertTrue(add_dialog._raid_chooser.get_visible())
+        self.assertEqual(add_dialog._raid_chooser.selected_level.name, "raid0")  # linear is default value for mdraid
 
-        # only 2 parents --> only "linear", "raid1" and "raid0" should be available; "raid5" needs at least 3 parents
-        # set_active_id returns True or False based on success --> it should return False for "raid5" and True otherwise
-        self.assertTrue(add_dialog.raid_combo.set_active_id("raid0"))
-        self.assertTrue(add_dialog.raid_combo.set_active_id("raid1"))
-        self.assertFalse(add_dialog.raid_combo.set_active_id("raid5"))
-
-        # raid1 type is selected --> we should have 2 size areas, both with max size 4 GiB (smaller free space size)
-        self.assertEqual(add_dialog.size_area.max_size, Size("4 GiB"))
+        # raid0 type is selected --> we should have 2 size areas, both with max size 4 GiB (smaller free space size)
+        self.assertEqual(add_dialog.size_area.max_size, Size("8 GiB"))
 
     @patch("blivetgui.dialogs.message_dialogs.ErrorDialog", error_dialog)
     def test_encrypt_validity_check(self):
@@ -825,7 +819,7 @@ class AddDialogTest(unittest.TestCase):
         add_dialog.on_cell_toggled(None, 1)
         add_dialog.parents_store[1][2] = True
 
-        add_dialog.raid_combo.set_active_id(raidtype)
+        add_dialog._raid_chooser._combobox_raid.set_active_id(raidtype)
 
         # raid 0 --> second size area should be updated
         add_dialog.size_area.parent_area.choosers[0].selected_size = size
@@ -846,7 +840,7 @@ class AddDialogTest(unittest.TestCase):
         self.assertFalse(selection.encrypt)
         self.assertTrue(selection.passphrase in (None, ""))
         self.assertEqual(selection.parents, [(parent_device1, size), (parent_device2, size)])
-        self.assertEqual(selection.raid_level, "raid0")
+        self.assertEqual(selection.raid_level, raidtype)
 
     def test_btrfs_selection(self):
         parent_device = self._get_parent_device()
@@ -873,7 +867,7 @@ class AddDialogTest(unittest.TestCase):
         self.assertFalse(selection.encrypt)
         self.assertTrue(selection.passphrase in (None, ""))
         self.assertEqual(selection.parents, [(parent_device, free_device.size)])
-        self.assertTrue(selection.raid_level in (None, ""))
+        self.assertEqual(selection.raid_level, "single")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/blivetgui_tests/size_widgets_test.py
+++ b/tests/blivetgui_tests/size_widgets_test.py
@@ -1,0 +1,1015 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from unittest.mock import MagicMock
+
+from blivetgui.dialogs.size_chooser import SizeChooser, ParentChooser, ParentArea, SizeArea, UNITS
+
+import os
+
+from blivet.size import Size, unit_str
+from blivet.devicelibs.raid import Single, Linear, RAID0, RAID1
+
+
+@unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
+class SizeAreaTest(unittest.TestCase):
+
+    def _mock_device(self, name="vda1", fmt_type=None):
+        dev = MagicMock()
+        fmt = MagicMock(type=fmt_type)
+        dev.configure_mock(name=name, format=fmt)
+
+        return dev
+
+    def test_10_basic(self):
+        """ Test basic SizeArea functionality """
+
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        # -- Partition -> no advanced selection
+        size_area = SizeArea(device_type="partition", parents=parents,
+                             min_limit=Size("1 MiB"), max_limit=Size("1 GiB"),
+                             raid_type=None)
+
+        # we need to get the checkbutton from builder
+        checkbutton_manual = size_area._builder.get_object("checkbutton_manual")
+
+        self.assertTrue(size_area.main_chooser.get_sensitive())
+        self.assertFalse(checkbutton_manual.get_sensitive())
+        self.assertFalse(checkbutton_manual.get_active())
+        self.assertIsNone(size_area._parent_area)
+
+        self.assertEqual(size_area.min_size, Size("1 MiB"))
+        self.assertEqual(size_area.max_size, Size("1 GiB"))
+
+        # try to update min size of all parents
+        size_area.set_parents_min_size(Size("2 MiB"))
+        self.assertEqual(size_area.min_size, Size("2 MiB"))
+        self.assertEqual(size_area.parents[0].min_size, Size("2 MiB"))
+
+        selection = size_area.get_selection()
+        self.assertEqual(selection.total_size, size_area.main_chooser.selected_size)
+        self.assertEqual(len(selection.parents), 1)
+        self.assertEqual(selection.parents[0].parent_device, parents[0].device)
+        self.assertEqual(selection.parents[0].selected_size, size_area.main_chooser.selected_size)
+
+    def test_20_advanced_allowed(self):
+        """ Test SizeArea functionality with ParentArea allowed """
+
+        # -- Btrfs volume, no raid -> advanced allowed
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="btrfs volume", parents=parents,
+                             min_limit=Size("1 MiB"), max_limit=Size("1 GiB"),
+                             raid_type=Single)
+
+        # we need to get the checkbutton from builder
+        checkbutton_manual = size_area._builder.get_object("checkbutton_manual")
+
+        self.assertTrue(size_area.main_chooser.get_sensitive())
+        self.assertTrue(checkbutton_manual.get_sensitive())
+        self.assertFalse(checkbutton_manual.get_active())
+        self.assertIsNone(size_area._parent_area)
+
+        # now select advanced
+        checkbutton_manual.set_active(True)
+        self.assertIsNotNone(size_area._parent_area)
+        self.assertFalse(size_area.main_chooser.get_sensitive())
+
+        selection = size_area.get_selection()
+        self.assertEqual(selection.total_size, Size("2 GiB"))  # Single raid, total size is just sum of parents
+        self.assertEqual(len(selection.parents), 2)
+        self.assertEqual(selection.parents[0].parent_device, parents[0].device)
+        self.assertEqual(selection.parents[0].selected_size, Size("1 GiB"))
+        self.assertEqual(selection.parents[1].parent_device, parents[1].device)
+        self.assertEqual(selection.parents[1].selected_size, Size("1 GiB"))
+
+        # setting min size with advanced enabled sets min size for all choosers
+        # resulting min size is then sum of the min sizes (with 'single' raid)
+        size_area.set_parents_min_size(Size("2 MiB"))
+        self.assertEqual(size_area.min_size, Size("4 MiB"))
+        self.assertTrue(all(p.min_size == Size("2 MiB") for p in size_area.parents))
+
+        size_area.set_parents_min_size(Size("1 MiB"))  # set it back for next test
+
+        # now deselect it
+        checkbutton_manual.set_active(False)
+        self.assertIsNone(size_area._parent_area)
+        self.assertTrue(size_area.main_chooser.get_sensitive())
+
+        # single, main chooser max should be 2 GiB and min should be 2 MiB
+        self.assertEqual(size_area.main_chooser.max_size, sum(p.max_size for p in parents))
+        self.assertEqual(size_area.main_chooser.min_size, sum(p.min_size for p in parents))
+
+        selection = size_area.get_selection()
+        self.assertEqual(selection.total_size, size_area.main_chooser.selected_size)
+        self.assertEqual(len(selection.parents), 2)
+        self.assertEqual(selection.parents[0].parent_device, parents[0].device)
+        self.assertEqual(selection.parents[0].selected_size, size_area.main_chooser.selected_size // 2)
+        self.assertEqual(selection.parents[1].parent_device, parents[1].device)
+        self.assertEqual(selection.parents[1].selected_size, size_area.main_chooser.selected_size // 2)
+
+    def test_30_advanced_enforced(self):
+        """ Test SizeArea functionality with ParentArea enforced """
+
+        # -- MDRAID, raid1 -> advanced enforced
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="mdraid", parents=parents,
+                             min_limit=Size("1 MiB"), max_limit=Size("1 GiB"),
+                             raid_type=RAID1)
+
+        # we need to get the checkbutton from builder
+        checkbutton_manual = size_area._builder.get_object("checkbutton_manual")
+
+        self.assertFalse(size_area.main_chooser.get_sensitive())
+        self.assertFalse(checkbutton_manual.get_sensitive())
+        self.assertTrue(checkbutton_manual.get_active())
+        self.assertIsNotNone(size_area._parent_area)
+
+        # raid1, main chooser max should be 1 GiB and min should be 1 MiB
+        self.assertEqual(size_area.main_chooser.max_size, min(p.max_size for p in parents))
+        self.assertEqual(size_area.main_chooser.min_size, min(p.min_size for p in parents))
+
+        # setting min size with advanced enabled sets min size for all choosers
+        # with raid1 resulting min size will still be 2 MiB (because it shows
+        # 'usable' min size)
+        size_area.set_parents_min_size(Size("2 MiB"))
+        self.assertEqual(size_area.min_size, Size("2 MiB"))
+
+        selection = size_area.get_selection()
+        self.assertEqual(selection.total_size, Size("1 GiB"))  # RAID1 with two 1 GiB parents
+        self.assertEqual(selection.parents[0].parent_device, parents[0].device)
+        self.assertEqual(selection.parents[0].selected_size, Size("1 GiB"))
+        self.assertEqual(selection.parents[1].parent_device, parents[1].device)
+        self.assertEqual(selection.parents[1].selected_size, Size("1 GiB"))
+
+    def test_40_basic_limits(self):
+        """ Test SizeArea limits functionality without ParentArea """
+
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="lvm", parents=parents,
+                             min_limit=Size(1), max_limit=Size("200 GiB"),
+                             raid_type=None)
+
+        # min size is based on both min size of the parents and limits
+        # limits are smaller here, so parents' min size win
+        self.assertEqual(size_area.min_size, sum(p.min_size for p in parents))
+
+        # max size is based on both max size of the parents and limits
+        # limits are bigger here, so parents' max size win
+        self.assertEqual(size_area.max_size, sum(p.max_size for p in parents))
+
+        # set min limits for parents -- this would happen e.g. when selecting
+        # encryption ('parent partitions' needs to be bigger because of the
+        # luks container)
+        size_area.set_parents_min_size(Size("3 MiB"))
+
+        self.assertEqual(size_area.min_size, Size("6 MiB"))  # 2 parents each min 3 MiB
+        self.assertEqual(size_area.main_chooser.min_size, Size("6 MiB"))
+        for parent in size_area.parents:
+            self.assertEqual(parent.min_size, Size("3 MiB"))
+
+        # now set 'global' min limit for the device -- this would happen e.g.
+        # when changing filesystem type to btrfs (final btrfs volume has to be
+        # at least 256 MiB big)
+        size_area.min_size_limit = Size("256 MiB")
+        self.assertEqual(size_area.min_size, Size("256 MiB"))
+        self.assertEqual(size_area.main_chooser.min_size, Size("256 MiB"))
+
+        # update parent min size to something smaller than current limit
+        # min_size_limit is bigger so it should win
+        size_area.set_parents_min_size(Size("10 MiB"))
+        self.assertEqual(size_area.min_size, Size("256 MiB"))
+
+        # update parent min size to something bigger than current limit
+        size_area.set_parents_min_size(Size("200 MiB"))  # 2*200 > 256
+        self.assertEqual(size_area.min_size, Size("400 MiB"))
+
+        # now just try to set 'global' limit to something smaller
+        # parent limit should win
+        size_area.min_size_limit = Size("300 MiB")
+        self.assertEqual(size_area.min_size, Size("400 MiB"))
+
+        # ---------------------------------------------------------------------#
+        # same for max size but there is no option to set max size for all
+        # parents (because it depends on selected parent and its free space)
+        # only setting max limit is supported
+        size_area.max_size_limit = Size("500 MiB")
+        self.assertEqual(size_area.max_size, Size("500 MiB"))
+        self.assertEqual(size_area.main_chooser.max_size, Size("500 MiB"))
+
+        # ---------------------------------------------------------------------#
+        # invalid limits
+        with self.assertRaises(ValueError):
+            size_area.min_size_limit = Size("100 TiB")  # bigger than max size
+
+        with self.assertRaises(ValueError):
+            size_area.min_size_limit = Size(0)
+
+        with self.assertRaises(ValueError):
+            size_area.max_size_limit = Size(1)  # smaller tnan min size
+
+        with self.assertRaises(ValueError):
+            size_area.max_size_limit = Size(-10)  # smaller tnan min size
+
+    def test_50_advanced_limits(self):
+        """ Test SizeArea limits functionality with ParentArea """
+
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="lvmlv", parents=parents,
+                             min_limit=Size(1), max_limit=Size("200 GiB"),
+                             raid_type=Linear)
+
+        # select advanced
+        checkbutton_manual = size_area._builder.get_object("checkbutton_manual")
+        checkbutton_manual.set_active(True)
+        self.assertIsNotNone(size_area._parent_area)  # just to be sure
+
+        # min size is based on both min size of the parents and limits
+        # limits are smaller here, so parents' min size win
+        self.assertEqual(size_area.min_size, sum(p.min_size for p in parents))
+
+        # max size is based on both max size of the parents and limits
+        # limits are bigger here, so parents' max size win
+        self.assertEqual(size_area.max_size, sum(p.max_size for p in parents))
+
+        # set same min size for all parents
+        size_area.set_parents_min_size(Size("5 MiB"))
+
+        self.assertEqual(size_area.min_size, Size("10 MiB"))  # 2 parents each min 5 MiB and Linear raid level
+        for parent in size_area.parents:
+            self.assertEqual(parent.min_size, Size("5 MiB"))
+        for chooser in size_area._parent_area.choosers:
+            self.assertEqual(chooser.min_size, Size("5 MiB"))
+
+        # now set 'global' limit -- in this case, no UI elements are changed,
+        # because this would be very hard for multiple parents with size choosers
+        # and with different raid levels etc.; validation of user input should
+        # fail instead
+        size_area.min_size_limit = Size("256 MiB")
+
+        valid, _reason = size_area.validate_user_input()
+        self.assertTrue(valid)  # valid now, because default is max size
+
+        self.assertEqual(size_area.min_size, Size("10 MiB"))  # min size shouldn't change
+        for chooser in size_area._parent_area.choosers:
+            chooser.selected_size = chooser.min_size  # set min size for all choosers
+        self.assertEqual(size_area.main_chooser.selected_size, Size("10 MiB"))
+
+        valid, _reason = size_area.validate_user_input()
+        self.assertFalse(valid)  # too small, invalid
+
+        # same for max limit; just set min_size_limit back
+        size_area.min_size_limit = Size("1 MiB")
+
+        max_pre = size_area.max_size
+        size_area.max_size_limit = Size("500 MiB")
+        self.assertEqual(size_area.max_size, max_pre)  # max size shouldn't change
+
+        for chooser in size_area._parent_area.choosers:
+            chooser.selected_size = chooser.max_size
+
+        valid, _reason = size_area.validate_user_input()
+        self.assertFalse(valid)  # invalid now, because max size > limit
+
+        for chooser in size_area._parent_area.choosers:
+            chooser.selected_size = chooser.min_size  # set min size for all choosers
+
+        valid, _reason = size_area.validate_user_input()
+        self.assertTrue(valid)  # valid now
+
+    def test_50_advanced_limits_raid(self):
+        """ Test SizeArea limits functionality with ParentArea with RAID """
+
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="lvmlv", parents=parents,
+                             min_limit=Size(1), max_limit=Size("200 GiB"),
+                             raid_type=RAID1)
+
+        # advanced should be preselected
+        self.assertIsNotNone(size_area._parent_area)
+
+        # min size is based on both min size of the parents and limits
+        # limits are smaller here, so parents' min size win (and it isn't sum
+        # of all parents because of RAID1)
+        self.assertEqual(size_area.min_size, min(p.min_size for p in parents))
+
+        # max size is based on both max size of the parents and limits
+        # limits are bigger here, so parents' max size win
+        self.assertEqual(size_area.max_size, min(p.max_size for p in parents))
+
+        # set same min size for all parents
+        size_area.set_parents_min_size(Size("255 MiB"))
+
+        self.assertEqual(size_area.min_size, Size("255 MiB"))  # 2 parents each min 2555 MiB and RAID1
+        for parent in size_area.parents:
+            self.assertEqual(parent.min_size, Size("255 MiB"))
+        for chooser in size_area._parent_area.choosers:
+            self.assertEqual(chooser.min_size, Size("255 MiB"))
+
+        # now set 'global' limit -- in this case, no UI elements are changed,
+        # because this would be very hard for multiple parents with size choosers
+        # and with different raid levels etc.; validation of user input should
+        # fail instead
+        size_area.min_size_limit = Size("256 MiB")
+
+        valid, _reason = size_area.validate_user_input()
+        self.assertTrue(valid)  # valid now, because default is max size
+
+        self.assertEqual(size_area.min_size, Size("255 MiB"))  # min size shouldn't change
+        for chooser in size_area._parent_area.choosers:
+            chooser.selected_size = chooser.min_size  # set min size for all choosers
+        self.assertEqual(size_area.main_chooser.selected_size, Size("255 MiB"))
+
+        valid, _reason = size_area.validate_user_input()
+        self.assertFalse(valid)  # too small, invalid
+
+    def test_60_reserved_size(self):
+        """ Test SizeArea reserved size functionality without ParentArea """
+
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="lvm", parents=parents,
+                             min_limit=Size(1), max_limit=Size("200 GiB"),
+                             raid_type=None)
+
+        # now set reserved size to 2 MiB
+        size_area.set_parents_reserved_size(Size("2 MiB"))
+
+        for parent in parents:
+            self.assertEqual(parent.reserved_size, Size("2 MiB"))
+
+        # min size should be 6 MiB now -- 2 * min_size + 2 * reserved_size
+        self.assertEqual(size_area.min_size, Size("6 MiB"))
+
+        # now set reserved size back to 0
+        size_area.set_parents_reserved_size(Size(0))
+
+        for parent in parents:
+            self.assertEqual(parent.reserved_size, Size(0))
+
+        # min size should be 2 MiB now -- just 2 * min_size
+        self.assertEqual(size_area.min_size, Size("2 MiB"))
+
+    def test_60_reserved_size_advanced(self):
+        """ Test SizeArea reserved size functionality with ParentArea """
+
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="lvm", parents=parents,
+                             min_limit=Size(1), max_limit=Size("200 GiB"),
+                             raid_type=None)
+
+        # select advanced
+        checkbutton_manual = size_area._builder.get_object("checkbutton_manual")
+        checkbutton_manual.set_active(True)
+        self.assertIsNotNone(size_area._parent_area)  # just to be sure
+
+        # now set reserved size to 2 MiB
+        size_area.set_parents_reserved_size(Size("2 MiB"))
+
+        for parent in parents:
+            self.assertEqual(parent.reserved_size, Size("2 MiB"))
+
+        # 'total' min size should be 6 MiB now -- 2 * min_size + 2 * reserved_size
+        self.assertEqual(size_area.min_size, Size("6 MiB"))
+
+        # min size per parent should 3 MiB -- 1 MiB for min_size and 2 MiB for reserved_size
+        for chooser in size_area._parent_area.choosers:
+            self.assertEqual(chooser.reserved_size, Size("2 MiB"))
+            self.assertEqual(chooser.min_size, Size("3 MiB"))
+
+        # now set reserved size back to 0
+        size_area.set_parents_reserved_size(Size(0))
+
+        for parent in parents:
+            self.assertEqual(parent.reserved_size, Size(0))
+
+        # 'total' min size should be 2 MiB now -- just 2 * min_size
+        self.assertEqual(size_area.min_size, Size("2 MiB"))
+
+        # min size per parent should 1 MiB -- just 1 MiB for min_size
+        for chooser in size_area._parent_area.choosers:
+            self.assertEqual(chooser.reserved_size, Size(0))
+            self.assertEqual(chooser.min_size, Size("1 MiB"))
+
+    def test_70_parent_allocation(self):
+        """ Test allocating size on parents without ParentArea """
+
+        # -- same size parents
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="lvm", parents=parents,
+                             min_limit=Size(1), max_limit=Size("200 GiB"),
+                             raid_type=None)
+
+        # select maximum --> both parents should have max_size selected
+        size_area.main_chooser.selected_size = Size("2 GiB")
+        ret = size_area._get_parents_allocation()
+        self.assertEqual(ret[0].parent_device, parents[0].device)
+        self.assertEqual(ret[0].selected_size, parents[0].max_size)
+        self.assertEqual(ret[1].parent_device, parents[1].device)
+        self.assertEqual(ret[1].selected_size, parents[1].max_size)
+
+        # -- two parents 1 GiB and 2 GiB
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("2 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="lvm", parents=parents,
+                             min_limit=Size(1), max_limit=Size("200 GiB"),
+                             raid_type=None)
+
+        # select 2 GiB --> 1 GiB on both should be selected
+        size_area.main_chooser.selected_size = Size("2 GiB")
+        ret = size_area._get_parents_allocation()
+        self.assertEqual(ret[0].parent_device, parents[0].device)
+        self.assertEqual(ret[0].selected_size, parents[0].max_size)
+        self.assertEqual(ret[1].parent_device, parents[1].device)
+        self.assertEqual(ret[1].selected_size, Size("1 GiB"))
+
+        # select 100 MiB --> 50 MiB on both should be selected
+        size_area.main_chooser.selected_size = Size("100 MiB")
+        ret = size_area._get_parents_allocation()
+        self.assertEqual(ret[0].parent_device, parents[0].device)
+        self.assertEqual(ret[0].selected_size, Size("50 MiB"))
+        self.assertEqual(ret[1].parent_device, parents[1].device)
+        self.assertEqual(ret[1].selected_size, Size("50 MiB"))
+
+        # -- three parents 1 GiB, 2 GiB and 5 GiB
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("2 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("5 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="lvm", parents=parents,
+                             min_limit=Size(1), max_limit=Size("200 GiB"),
+                             raid_type=None)
+
+        # select 3 GiB --> 1 GiB on both should be selected
+        size_area.main_chooser.selected_size = Size("3 GiB")
+        ret = size_area._get_parents_allocation()
+        selected_sizes = [r.selected_size for r in ret]
+
+        # with 3 parents result might be in different order, so just check
+        # sequence of the sizes and that none of the parents has bigger selected
+        # size than its max size
+        self.assertListEqual(selected_sizes, [Size("1 GiB"), Size("1 GiB"), Size("1 GiB")])
+        for parent in parents:
+            for r in ret:
+                if parent.device == r.parent_device:
+                    self.assertLessEqual(r.selected_size, parent.max_size)
+
+        # select 1 GiB --> 1/3 GiB on all should be selected (one will be 1/3 + rest)
+        size_area.main_chooser.selected_size = Size("1 GiB")
+        ret = size_area._get_parents_allocation()
+        selected_sizes = [r.selected_size for r in ret]
+
+        # with 3 parents result might be in different order, so just check
+        # sequence of the sizes and that none of the parents has bigger selected
+        # size than its max size
+        self.assertListEqual(selected_sizes, [Size("1 GiB") / 3, Size("1 GiB") / 3, Size("1 GiB") - 2 * Size("1 GiB") / 3])
+        for parent in parents:
+            for r in ret:
+                if parent.device == r.parent_device:
+                    self.assertLessEqual(r.selected_size, parent.max_size)
+
+        # select 7 GiB --> 1, 2 and 4 GiB should be selected
+        size_area.main_chooser.selected_size = Size("7 GiB")
+        ret = size_area._get_parents_allocation()
+        selected_sizes = [r.selected_size for r in ret]
+
+        # with 3 parents result might be in different order, so just check
+        # sequence of the sizes and that none of the parents has bigger selected
+        # size than its max size
+        self.assertListEqual(selected_sizes, [Size("1 GiB"), Size("2 GiB"), Size("4 GiB")])
+        for parent in parents:
+            for r in ret:
+                if parent.device == r.parent_device:
+                    self.assertLessEqual(r.selected_size, parent.max_size)
+
+        # -- just some crazy corner case
+        parents = [MagicMock(device=self._mock_device(), min_size=Size(1), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size(1), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        size_area = SizeArea(device_type="lvm", parents=parents,
+                             min_limit=Size(1), max_limit=Size("200 GiB"),
+                             raid_type=None)
+
+        # select 3 and see how it will be devided between 2 devices
+        size_area.main_chooser.selected_size = Size(3)
+        ret = size_area._get_parents_allocation()
+        selected_sizes = [r.selected_size for r in ret]
+        self.assertListEqual(selected_sizes, [Size(1), Size(2)])
+
+
+@unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
+class ParentAreaTest(unittest.TestCase):
+
+    def _mock_device(self, name="vda1", fmt_type=None):
+        dev = MagicMock()
+        fmt = MagicMock(type=fmt_type)
+        dev.configure_mock(name=name, format=fmt)
+
+        return dev
+
+    def test_10_basic(self):
+        """ Test basic ParentArea functionality """
+
+        # -- MDRAID
+        main_chooser = MagicMock()
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        parent_area = ParentArea(device_type="mdraid", parents=parents, raid_type=RAID0,
+                                 main_chooser=main_chooser)
+
+        # two choosers, both should be selected (and not selectable) with given min and max size
+        self.assertEqual(len(parent_area.choosers), 2)
+        self.assertListEqual(parent_area.choosers, parent_area.selected_choosers)
+
+        for idx, chooser in enumerate(parent_area.choosers):
+            self.assertTrue(chooser.selected)
+            self.assertFalse(chooser.checkbutton_use.get_sensitive())
+            self.assertTrue(chooser.size_chooser.get_sensitive())
+            self.assertEqual(chooser.min_size, parents[idx].min_size)
+            self.assertEqual(chooser.max_size, parents[idx].max_size)
+            self.assertEqual(chooser.selected_size, parents[idx].max_size)
+
+        # test area size limits
+        self.assertEqual(parent_area.total_max, sum(p.max_size for p in parents))
+        self.assertEqual(parent_area.total_min, sum(p.min_size for p in parents))
+        self.assertEqual(parent_area.total_size, sum(p.max_size for p in parents))
+
+        # -- LVM (with both free space and lvmpv parents)
+        main_chooser = MagicMock()
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(fmt_type="lvmpv"), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        parent_area = ParentArea(device_type="lvm", parents=parents, raid_type=None,
+                                 main_chooser=main_chooser)
+
+        # two choosers, both should be selected (and not selectable) with given min and max size
+        self.assertEqual(len(parent_area.choosers), 2)
+        self.assertListEqual(parent_area.choosers, parent_area.selected_choosers)
+
+        for idx, chooser in enumerate(parent_area.choosers):
+            self.assertTrue(chooser.selected)
+            self.assertFalse(chooser.checkbutton_use.get_sensitive())
+            self.assertEqual(chooser.min_size, parents[idx].min_size)
+            self.assertEqual(chooser.max_size, parents[idx].max_size)
+            self.assertEqual(chooser.selected_size, parents[idx].max_size)
+
+        # test area size limits
+        self.assertEqual(parent_area.total_max, sum(p.max_size for p in parents))
+        self.assertEqual(parent_area.total_min, sum(p.min_size for p in parents))
+        self.assertEqual(parent_area.total_size, sum(p.max_size for p in parents))
+
+        # size should be selectable just for the free space, not for the PV
+        self.assertTrue(parent_area.choosers[0].size_chooser.get_sensitive())
+        self.assertFalse(parent_area.choosers[1].size_chooser.get_sensitive())
+
+    def test_20_parent_selection(self):
+        """ Test ParentArea functionality when (de)selecting some parents """
+
+        main_chooser = MagicMock()
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"), reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"), reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"), reserved_size=Size(0))]
+
+        # RAID LV is the only device type that allows changing parent selection
+        parent_area = ParentArea(device_type="lvmlv", parents=parents, raid_type=RAID0,
+                                 main_chooser=main_chooser)
+
+        # three choosers, all should be selected (and selectable) with given min and max size
+        self.assertEqual(len(parent_area.choosers), 3)
+
+        for idx, chooser in enumerate(parent_area.choosers):
+            self.assertTrue(chooser.selected)
+            self.assertTrue(chooser.checkbutton_use.get_sensitive())
+            self.assertEqual(chooser.min_size, parents[idx].min_size)
+            self.assertEqual(chooser.max_size, parents[idx].max_size)
+            self.assertEqual(chooser.selected_size, parents[idx].max_size)
+
+        # test area size limits
+        self.assertEqual(parent_area.total_max, sum(p.max_size for p in parents))
+        self.assertEqual(parent_area.total_min, sum(p.min_size for p in parents))
+        self.assertEqual(parent_area.total_size, sum(p.max_size for p in parents))
+
+        # try to deselect first parent
+        # after it, shouldn't be possible to deselect more parents -> not enough
+        # members for RAID0
+        parent_area.choosers[0].selected = False
+        self.assertEqual(parent_area.total_max, sum(p.max_size for p in parents[1:]))
+        self.assertEqual(parent_area.total_min, sum(p.min_size for p in parents[1:]))
+        self.assertEqual(parent_area.total_size, sum(p.max_size for p in parents[1:]))
+
+        self.assertFalse(parent_area.choosers[1].parent_selectable)
+        self.assertFalse(parent_area.choosers[2].parent_selectable)
+
+        # select first parent again, everything should be back to normal
+        parent_area.choosers[0].selected = True
+        self.assertTrue(parent_area.choosers[1].parent_selectable)
+        self.assertTrue(parent_area.choosers[2].parent_selectable)
+
+    def test_30_size_selection(self):
+        """ Test ParentArea functionality when changing size of some parents """
+
+        main_chooser = MagicMock()
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        parent_area = ParentArea(device_type="mdraid", parents=parents, raid_type=RAID0,
+                                 main_chooser=main_chooser)
+
+        # change size of first chooser, second should be automatically adjusted
+        parent_area.choosers[0].selected_size = Size("500 MiB")
+        self.assertEqual(parent_area.choosers[1].selected_size, Size("500 MiB"))
+
+    def test_40_main_update(self):
+        """ Test updating values of main chooser in SizeArea """
+
+        # -- MDRAID
+        main_chooser = SizeChooser(max_size=Size(0), min_size=Size(0))
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        parent_area = ParentArea(device_type="mdraid", parents=parents, raid_type=RAID1,
+                                 main_chooser=main_chooser)
+
+        # raid1, main chooser max should be 1 GiB and min should be 1 MiB
+        self.assertEqual(parent_area.main_chooser.max_size, min(p.max_size for p in parents))
+        self.assertEqual(parent_area.main_chooser.min_size, min(p.min_size for p in parents))
+
+        # set new size, parent area should be updated
+        parent_area.choosers[0].selected_size = Size("500 MiB")
+        self.assertEqual(parent_area.main_chooser.selected_size, Size("500 MiB"))
+
+        # -- LVM RAID
+        main_chooser = SizeChooser(max_size=Size(0), min_size=Size(0))
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"), reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"), reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"), reserved_size=Size(0))]
+
+        parent_area = ParentArea(device_type="lvmlv", parents=parents, raid_type=RAID0,
+                                 main_chooser=main_chooser)
+
+        # raid0, main chooser max should be 3 GiB and min should be 3 MiB
+        self.assertEqual(parent_area.main_chooser.max_size, sum(p.max_size for p in parents))
+        self.assertEqual(parent_area.main_chooser.min_size, sum(p.min_size for p in parents))
+
+        # deselect one parent -- max should be 2 GiB and min should be 2 MiB
+        parent_area.choosers[0].selected = False
+        self.assertEqual(parent_area.main_chooser.max_size, sum(p.max_size for p in parents[1:]))
+        self.assertEqual(parent_area.main_chooser.min_size, sum(p.min_size for p in parents[1:]))
+
+    def test_50_selected(self):
+        """ Test if widget returns what user selected """
+
+        # -- MDRAID, simple selection, all parents, just size adjusted
+        main_chooser = MagicMock()
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        parent_area = ParentArea(device_type="mdraid", parents=parents, raid_type=RAID0,
+                                 main_chooser=main_chooser)
+
+        parent_area.choosers[0].selected_size = Size("500 MiB")
+        selection = parent_area.get_selection()
+        self.assertEqual(selection.total_size, Size("1000 MiB"))  # RAID 0 with two 500 MiB parents
+        self.assertEqual(selection.parents[0].parent_device, parents[0].device)
+        self.assertEqual(selection.parents[0].selected_size, Size("500 MiB"))
+        self.assertEqual(selection.parents[1].parent_device, parents[1].device)
+        self.assertEqual(selection.parents[1].selected_size, Size("500 MiB"))
+
+        # -- Btrfs volume,  size can be changed separately for all parents
+        main_chooser = MagicMock()
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                             reserved_size=Size(0))]
+
+        parent_area = ParentArea(device_type="btrfs volume", parents=parents, raid_type=Single,
+                                 main_chooser=main_chooser)
+
+        parent_area.choosers[0].selected_size = Size("500 MiB")
+        parent_area.choosers[1].selected_size = Size("750 MiB")
+        selection = parent_area.get_selection()
+        self.assertEqual(selection.total_size, Size("1250 MiB"))  # single with 500 MiB and 750 MiB parents
+        self.assertEqual(selection.parents[0].parent_device, parents[0].device)
+        self.assertEqual(selection.parents[0].selected_size, Size("500 MiB"))
+        self.assertEqual(selection.parents[1].parent_device, parents[1].device)
+        self.assertEqual(selection.parents[1].selected_size, Size("750 MiB"))
+
+        # -- LVM RAID, allows parent selection
+        main_chooser = MagicMock()
+        parents = [MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"), reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"), reserved_size=Size(0)),
+                   MagicMock(device=self._mock_device(), min_size=Size("1 MiB"), max_size=Size("1 GiB"), reserved_size=Size(0))]
+
+        parent_area = ParentArea(device_type="lvmlv", parents=parents, raid_type=RAID0,
+                                 main_chooser=main_chooser)
+
+        parent_area.choosers[0].selected = False
+        parent_area.choosers[1].selected_size = Size("500 MiB")
+        selection = parent_area.get_selection()
+        self.assertEqual(selection.total_size, Size("1000 MiB"))  # RAID0 with two 500 MiB parents
+        self.assertEqual(selection.parents[0].parent_device, parents[1].device)
+        self.assertEqual(selection.parents[0].selected_size, Size("500 MiB"))
+        self.assertEqual(selection.parents[1].parent_device, parents[2].device)
+        self.assertEqual(selection.parents[1].selected_size, Size("500 MiB"))
+
+
+@unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
+class ParentChooserTest(unittest.TestCase):
+
+    def test_10_basic(self):
+        """ Test basic ParentChooser functionality """
+        parent = MagicMock()
+        parent.configure_mock(name="vda")
+
+        chooser = ParentChooser(parent=parent, min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                                reserved_size=Size(0), selected=True, parent_selectable=False,
+                                size_selectable=True)
+        self.assertEqual(chooser.min_size, Size("1 MiB"))
+        self.assertEqual(chooser.max_size, Size("1 GiB"))
+
+        # checkbutton should be selected and insensitive
+        self.assertTrue(chooser.checkbutton_use.get_active())
+        self.assertFalse(chooser.checkbutton_use.get_sensitive())
+
+        # size chooser should be sensitive
+        self.assertTrue(chooser.size_chooser.get_sensitive())
+
+    def test_20_selection(self):
+        """ Test (de)selecting parent """
+        parent = MagicMock()
+        parent.configure_mock(name="vda")
+
+        chooser = ParentChooser(parent=parent, min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                                reserved_size=Size(0), selected=True, parent_selectable=True,
+                                size_selectable=True)
+
+        # checkbutton should be selected and sensitive
+        self.assertTrue(chooser.checkbutton_use.get_active())
+        self.assertTrue(chooser.checkbutton_use.get_sensitive())
+
+        # deselect -- size chooser should be insensitive and set to 0
+        chooser.selected = False
+
+        self.assertFalse(chooser.checkbutton_use.get_active())
+        self.assertFalse(chooser.size_chooser.get_sensitive())
+        self.assertEqual(chooser.size_chooser.min_size, 0)
+        self.assertEqual(chooser.size_chooser.selected_size, 0)
+
+        # and select again -- size chooser should be sensitive and set to max
+        chooser.selected = True
+
+        self.assertTrue(chooser.checkbutton_use.get_active())
+        self.assertTrue(chooser.size_chooser.get_sensitive())
+        self.assertEqual(chooser.size_chooser.min_size, chooser.min_size)
+        self.assertEqual(chooser.size_chooser.selected_size, chooser.max_size)
+
+        # and now deselect and select again using the button
+        chooser.checkbutton_use.set_active(False)
+        self.assertFalse(chooser.selected)
+
+        chooser.checkbutton_use.set_active(True)
+        self.assertTrue(chooser.selected)
+
+    def test_30_size_selection(self):
+        """ Test chaning size selection """
+        parent = MagicMock()
+        parent.configure_mock(name="vda")
+
+        chooser = ParentChooser(parent=parent, min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                                reserved_size=Size(0), selected=True, parent_selectable=False,
+                                size_selectable=True)
+
+        # by default max size should be selected
+        self.assertEqual(chooser.selected_size, Size("1 GiB"))
+
+        # select some different size
+        chooser.selected_size = Size("500 MiB")
+        self.assertEqual(chooser.selected_size, Size("500 MiB"))
+
+    def test_40_limits(self):
+        """ Test setting limits (min/max size) """
+        parent = MagicMock()
+        parent.configure_mock(name="vda")
+
+        chooser = ParentChooser(parent=parent, min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                                reserved_size=Size(0), selected=True, parent_selectable=False,
+                                size_selectable=True)
+
+        # select max size and set new max size bigger (selection shouldn't change)
+        chooser.selected_size = chooser.max_size
+        size_before = chooser.selected_size
+        chooser.max_size = Size("2 GiB")
+        self.assertEqual(chooser.size_chooser.max_size, Size("2 GiB"))
+        self.assertEqual(chooser.selected_size, size_before)
+
+        # select max size and set new max size smaller (selection should be adjusted)
+        chooser.selected_size = chooser.max_size
+        chooser.max_size = Size("500 MiB")
+        self.assertEqual(chooser.size_chooser.max_size, Size("500 MiB"))
+        self.assertEqual(chooser.selected_size, Size("500 MiB"))
+
+        # select min size and set new min size smaller (selection shouldn't change)
+        chooser.selected_size = chooser.min_size
+        size_before = chooser.selected_size
+        chooser.min_size = Size("1 KiB")
+        self.assertEqual(chooser.size_chooser.min_size, Size("1 KiB"))
+        self.assertEqual(chooser.selected_size, size_before)
+
+        # select min size and set new min size bigger (selection should be adjusted)
+        chooser.selected_size = chooser.min_size
+        chooser.min_size = Size("2 MiB")
+        self.assertEqual(chooser.size_chooser.min_size, Size("2 MiB"))
+        self.assertEqual(chooser.selected_size, Size("2 MiB"))
+
+    def test_50_signals(self):
+        """ Test connecting signals and signal handling """
+        parent = MagicMock()
+        parent.configure_mock(name="vda")
+
+        chooser = ParentChooser(parent=parent, min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+                                reserved_size=Size(0), selected=True, parent_selectable=True,
+                                size_selectable=True)
+
+        parent_handler = MagicMock()
+        size_handler1 = MagicMock()
+        size_handler2 = MagicMock()
+
+        chooser.connect("parent-toggled", parent_handler)
+        chooser.connect("size-changed", size_handler1)
+        chooser.connect("size-changed", size_handler2)
+
+        # parent selection
+        chooser.checkbutton_use.set_active(False)
+        parent_handler.assert_called_with(False)
+
+        # size selection
+        chooser.size_chooser._scale.set_value(512)
+        size_handler1.assert_called_with(Size("512 MiB"))
+        size_handler2.assert_called_with(Size("512 MiB"))
+
+
+@unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
+class SizeChooserAreaTest(unittest.TestCase):
+
+    def setUp(self):
+        self.size_chooser = SizeChooser(max_size=Size("100 GiB"), min_size=Size("1 MiB"))
+
+    def test_10_unit_change(self):
+        original_size = self.size_chooser.selected_size
+
+        for idx, unit in enumerate(list(UNITS.keys())):
+            self.size_chooser._unit_chooser.set_active(idx)
+            self.assertEqual(unit.upper(), unit_str(self.size_chooser.selected_unit).upper())  # kB vs KB
+
+            new_size = Size(str(self.size_chooser._spin.get_value()) + " " + unit)
+            self.assertEqual(original_size, new_size)
+
+    def test_20_scale_spin(self):
+        old_value = self.size_chooser._scale.get_value()
+        new_value = old_value // 2
+
+        self.size_chooser._scale.set_value(new_value)
+        self.assertEqual(new_value, self.size_chooser._spin.get_value())
+
+        self.size_chooser._spin.set_value(old_value)
+        self.assertEqual(old_value, self.size_chooser._scale.get_value())
+
+    def test_30_get_size(self):
+        selected_size = Size(str(self.size_chooser._spin.get_value()) + " " + unit_str(self.size_chooser.selected_unit))
+        self.assertEqual(selected_size, self.size_chooser.selected_size)
+
+    def test_40_set_size(self):
+        selected_size = (self.size_chooser.max_size - self.size_chooser.min_size) // 2
+        self.size_chooser.selected_size = selected_size
+        self.assertEqual(selected_size, self.size_chooser.selected_size)
+
+        with self.assertRaises(ValueError):
+            self.size_chooser.selected_size = self.size_chooser.min_size - 1  # not between min and max
+
+        with self.assertRaises(ValueError):
+            self.size_chooser.selected_size = self.size_chooser.max_size + 1  # not between min and max
+
+    def test_50_set_limits(self):
+        self.size_chooser.min_size = Size("2 MiB")
+        self.assertEqual(self.size_chooser.min_size, Size("2 MiB"))
+
+        with self.assertRaises(ValueError):
+            self.size_chooser.min_size = self.size_chooser.max_size + 1  # bigger than max
+
+        self.size_chooser.max_size = Size("200 GiB")
+        self.assertEqual(self.size_chooser.max_size, Size("200 GiB"))
+
+        with self.assertRaises(ValueError):
+            self.size_chooser.max_size = self.size_chooser.min_size - 1  # smaller than min
+
+        self.size_chooser.selected_size = Size("50 GiB")  # selection should be preserved
+        self.size_chooser.update_size_limits(min_size=Size("5 MiB"), max_size=Size("75 GiB"))
+        self.assertEqual(self.size_chooser.min_size, Size("5 MiB"))
+        self.assertEqual(self.size_chooser.max_size, Size("75 GiB"))
+        self.assertEqual(self.size_chooser.selected_size, Size("50 GiB"))
+
+    def test_60_widget_status(self):
+        self.size_chooser.hide()
+        for widget in self.size_chooser.widgets:
+            if hasattr(widget, "get_visible"):
+                self.assertFalse(widget.get_visible())
+
+        self.size_chooser.show()
+        for widget in self.size_chooser.widgets:
+            if hasattr(widget, "get_visible"):
+                self.assertTrue(widget.get_visible())
+
+        self.size_chooser.set_sensitive(False)
+        for widget in self.size_chooser.widgets:
+            if hasattr(widget, "get_sensitive"):
+                self.assertFalse(widget.get_sensitive())
+
+        self.size_chooser.set_sensitive(True)
+        for widget in self.size_chooser.widgets:
+            if hasattr(widget, "get_sensitive"):
+                self.assertTrue(widget.get_sensitive())
+
+    def test_70_signals(self):
+        unit_handler = MagicMock()
+        size_handler1 = MagicMock()
+        size_handler2 = MagicMock()
+
+        self.size_chooser.connect("unit-changed", unit_handler)
+        self.size_chooser.connect("size-changed", size_handler1)
+        self.size_chooser.connect("size-changed", size_handler2, "foo")
+
+        with self.assertRaises(ValueError):
+            self.size_chooser.connect("non-existing-signal", None)
+
+        # parent selection
+        self.size_chooser._unit_chooser.set_active(list(UNITS.keys()).index("KiB"))
+        unit_handler.assert_called_with(UNITS["KiB"])
+
+        # size selection
+        old_value = self.size_chooser._scale.get_value()
+        new_value = old_value // 2
+        self.size_chooser._scale.set_value(new_value)
+
+        size_handler1.assert_called_with(self.size_chooser.selected_size)
+        size_handler2.assert_called_with(self.size_chooser.selected_size, "foo")
+
+    def test_80_selection(self):
+        self.size_chooser.selected_size = Size("125 MiB")
+
+        selection = self.size_chooser.get_selection()
+        self.assertEqual(selection, Size("125 MiB"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/blivetgui_tests/widgets_test.py
+++ b/tests/blivetgui_tests/widgets_test.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+
+from blivet.devicelibs.raid import RAID0, RAID1, RAID5, Single, Linear
+
+from blivetgui.dialogs.widgets import RaidChooser
+
+
+@unittest.skipUnless("DISPLAY" in os.environ.keys(), "requires X server")
+class RaidChooserTest(unittest.TestCase):
+
+    def test_10_update(self):
+        chooser = RaidChooser()
+        chooser.supported_raids = {"mdraid": [RAID0, RAID1, RAID5, Linear],
+                                   "lvmlv": [RAID0, RAID1, RAID5, Linear],
+                                   "btrfs volume": [RAID0, RAID1, RAID5, Single]}
+
+        # mdraid with 2 parents -> raid0, raid1 and linear should be available
+        # and autoselect should select raid0
+        # chooser should be visible and sensitive
+        chooser.update("mdraid", 2)
+        self.assertEqual(len(chooser._liststore_raid), 3)
+        self.assertListEqual([RAID0, RAID1, Linear], [row[1] for row in chooser._liststore_raid])
+
+        chooser.autoselect("mdraid")
+        self.assertEqual(chooser.selected_level, RAID0)
+        self.assertTrue(chooser.get_visible())
+        self.assertTrue(chooser.get_sensitive())
+
+        # btrfs with 3 parents -> raid0, raid1, raid5 and single should be available
+        # and autoselect should select single
+        # chooser should be visible and sensitive
+        chooser.update("btrfs volume", 3)
+        self.assertEqual(len(chooser._liststore_raid), 4)
+        self.assertListEqual([RAID0, RAID1, RAID5, Single], [row[1] for row in chooser._liststore_raid])
+
+        chooser.autoselect("btrfs volume")
+        self.assertEqual(chooser.selected_level, Single)
+        self.assertTrue(chooser.get_visible())
+        self.assertTrue(chooser.get_sensitive())
+
+        # lvmlv with 1 parent -> only linear should be available
+        # and autoselect should select linear
+        # chooser should be visible and insensitive
+        chooser.update("lvmlv", 1)
+        self.assertEqual(len(chooser._liststore_raid), 1)
+        self.assertListEqual([Linear], [row[1] for row in chooser._liststore_raid])
+
+        chooser.autoselect("lvmlv")
+        self.assertEqual(chooser.selected_level, Linear)
+        self.assertTrue(chooser.get_visible())
+        self.assertFalse(chooser.get_sensitive())
+
+        # partition with 1 parent -> no levels and None should be autoselected
+        # chooser should be invisible and insensitive
+        chooser.update("partition", 1)
+        self.assertEqual(len(chooser._liststore_raid), 0)
+
+        chooser.autoselect("partition")
+        self.assertEqual(chooser.selected_level, None)
+        self.assertFalse(chooser.get_visible())
+        self.assertFalse(chooser.get_sensitive())
+
+    def test_20_selection(self):
+        chooser = RaidChooser()
+        chooser.supported_raids = {"mdraid": [RAID0, RAID1, RAID5, Linear]}
+        chooser.update("mdraid", 2)
+
+        # raid5 not supported for 2 devices
+        with self.assertRaises(ValueError):
+            chooser.selected_level = RAID5
+
+        chooser.selected_level = RAID1
+        self.assertEqual(chooser.selected_level, RAID1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
There are two major changes in this PR:

- Changes related to size selection in AddDialog -- reworked SizeArea (now with tests!)
- Removing of support for LVM RAID and LVM cache -- these will be just temporary, but there is a lot of problems with allocating multiple LVs and having these features disabled will help with testing the blivet-gui integration to Anaconda
