### PR TITLE
AddDialog: Use 'free_space' instead of 'free' for VGs free space

### DIFF
--- a/blivetgui/dialogs/add_dialog.py
+++ b/blivetgui/dialogs/add_dialog.py
@@ -509,8 +509,8 @@ class AddDialog(Gtk.Dialog):
 
         elif self.selected_type in ("lvm snapshot",):
             # parent for a LVM snaphost is actually the VG, not the selected LV
-            self.parents_store.append([self.selected_parent, self.selected_parent.vg.free, False, False,
-                                       self.selected_parent.vg.name, "lvmvg", str(self.selected_parent.vg.free)])
+            self.parents_store.append([self.selected_parent, self.selected_parent.vg.free_space, False, False,
+                                       self.selected_parent.vg.name, "lvmvg", str(self.selected_parent.vg.free_space)])
 
         elif self.selected_type in ("lvm thinsnapshot",):
             # parent for an LVM thinsnaphost is actually the pool, not the selected thinLV


### PR DESCRIPTION
'free' is not updated after removing LVs

Resolves: rhbz#1429988