### PR TITLE
Preserve ordering when adding partitions (#1439591)

### DIFF
--- a/blivetgui/blivetgui.py
+++ b/blivetgui/blivetgui.py
@@ -413,7 +413,7 @@ class BlivetGUI(object):
             selected_free = selected_device
         else:
             selected_parent = selected_device
-            selected_free = selected_device
+            selected_free = self.client.remote_call("get_free_device", selected_device)
 
         if self.installer_mode:
             mountpoints = self.client.remote_call("get_mountpoints")

--- a/blivetgui/dialogs/size_chooser.py
+++ b/blivetgui/dialogs/size_chooser.py
@@ -63,8 +63,10 @@ class SizeSelection(ProxyDataContainer):
 
 class ParentSelection(ProxyDataContainer):
 
-    def __init__(self, parent_device, selected_size):
-        super().__init__(parent_device=parent_device, selected_size=selected_size)
+    def __init__(self, parent_device, free_space, selected_size):
+        super().__init__(parent_device=parent_device,
+                         free_space=free_space,
+                         selected_size=selected_size)
 
 # ---------------------------------------------------------------------------- #
 
@@ -299,12 +301,14 @@ class SizeArea(GUIWidget):
                 # just put remaining size / number of remaining parents to each parent
                 for parent in unallocated_parents:
                     res.append(ParentSelection(parent_device=parent.device,
+                                               free_space=parent.free_space,
                                                selected_size=(total_size - allocated_size) // len(unallocated_parents)))
                     allocated_size += ((total_size - allocated_size) // len(unallocated_parents))
                     unallocated_parents.remove(parent)
             else:
                 # use entire smallest remaining parent
                 res.append(ParentSelection(parent_device=smallest_parent.device,
+                                           free_space=smallest_parent.free_space,
                                            selected_size=smallest_parent.max_size))
                 allocated_size += smallest_parent.max_size
                 unallocated_parents.remove(smallest_parent)
@@ -413,6 +417,7 @@ class ParentArea(GUIWidget):
         for chooser in self.choosers:
             if chooser.selected:
                 parents.append(ParentSelection(parent_device=chooser.parent,
+                                               free_space=chooser.free_space,
                                                selected_size=chooser.selected_size))
 
         return SizeSelection(total_size=self.total_size, parents=parents)
@@ -468,7 +473,8 @@ class ParentArea(GUIWidget):
             # size is selectable for all parents except for PVs
             size_selectable = parent.device.format.type != "lvmpv"
 
-            chooser = ParentChooser(parent=parent.device, min_size=parent.min_size, max_size=max_size,
+            chooser = ParentChooser(parent=parent.device, free_space=parent.free_space,
+                                    min_size=parent.min_size, max_size=max_size,
                                     reserved_size=parent.reserved_size,
                                     selected=True, parent_selectable=parent_selectable,
                                     size_selectable=size_selectable)
@@ -533,11 +539,12 @@ class ParentChooser(GUIWidget):
     name = "parent chooser"
     glade_file = "parent_chooser.ui"
 
-    def __init__(self, parent, min_size, max_size, reserved_size, selected, parent_selectable, size_selectable):
+    def __init__(self, parent, free_space, min_size, max_size, reserved_size, selected, parent_selectable, size_selectable):
 
         super().__init__()
 
         self.parent = parent
+        self.free_space = free_space
         self._max_size = max_size
         self._min_size = min_size
         self._reserved_size = reserved_size

--- a/tests/blivetgui_tests/add_dialog_test.py
+++ b/tests/blivetgui_tests/add_dialog_test.py
@@ -369,7 +369,7 @@ class AddDialogTest(unittest.TestCase):
         # partition allows only one parent -- make sure we have the right one and it is selected
         self.assertEqual(len(add_dialog.parents_store), 1)
         self.assertEqual(add_dialog.parents_store[0][0], parent_device)
-        self.assertEqual(add_dialog.parents_store[0][1], free_device.size)
+        self.assertEqual(add_dialog.parents_store[0][1], free_device)
         self.assertTrue(add_dialog.parents_store[0][2])
         self.assertTrue(add_dialog.parents_store[0][3])
         self.assertEqual(add_dialog.parents_store[0][5], "disk")
@@ -385,7 +385,7 @@ class AddDialogTest(unittest.TestCase):
         # lvm allows multiple parents -- make sure we have all available and the right one is selected
         self.assertEqual(len(add_dialog.parents_store), 3)
         self.assertEqual(add_dialog.parents_store[0][0], parent_device)
-        self.assertEqual(add_dialog.parents_store[0][1], free_device.size)
+        self.assertEqual(add_dialog.parents_store[0][1], free_device)
         self.assertTrue(add_dialog.parents_store[0][2])
         self.assertFalse(add_dialog.parents_store[1][2])  # other two free devices shouldn't be selected
         self.assertFalse(add_dialog.parents_store[2][2])
@@ -401,7 +401,7 @@ class AddDialogTest(unittest.TestCase):
         # lvmlv allows only one parent -- make sure we have the right one and it is selected
         self.assertEqual(len(add_dialog.parents_store), 1)
         self.assertEqual(add_dialog.parents_store[0][0], parent_device)
-        self.assertEqual(add_dialog.parents_store[0][1], free_device.size)
+        self.assertEqual(add_dialog.parents_store[0][1], free_device)
         self.assertTrue(add_dialog.parents_store[0][2])
         self.assertTrue(add_dialog.parents_store[0][3])
         self.assertEqual(add_dialog.parents_store[0][5], "lvmvg")
@@ -417,7 +417,7 @@ class AddDialogTest(unittest.TestCase):
         # lvm allows multiple parents -- make sure we have all available (= larger than 256 MiB) and the right one is selected
         self.assertEqual(len(add_dialog.parents_store), 2)  # third device is smaller than min size for btrfs
         self.assertEqual(add_dialog.parents_store[0][0], parent_device)
-        self.assertEqual(add_dialog.parents_store[0][1], free_device.size)
+        self.assertEqual(add_dialog.parents_store[0][1], free_device)
         self.assertTrue(add_dialog.parents_store[0][2])
         self.assertFalse(add_dialog.parents_store[1][2])  # other free device shouldn't be selected
 

--- a/tests/blivetgui_tests/size_widgets_test.py
+++ b/tests/blivetgui_tests/size_widgets_test.py
@@ -772,8 +772,10 @@ class ParentChooserTest(unittest.TestCase):
         """ Test basic ParentChooser functionality """
         parent = MagicMock()
         parent.configure_mock(name="vda")
+        free = MagicMock()
 
-        chooser = ParentChooser(parent=parent, min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+        chooser = ParentChooser(parent=parent, free_space=free,
+                                min_size=Size("1 MiB"), max_size=Size("1 GiB"),
                                 reserved_size=Size(0), selected=True, parent_selectable=False,
                                 size_selectable=True)
         self.assertEqual(chooser.min_size, Size("1 MiB"))
@@ -790,8 +792,10 @@ class ParentChooserTest(unittest.TestCase):
         """ Test (de)selecting parent """
         parent = MagicMock()
         parent.configure_mock(name="vda")
+        free = MagicMock()
 
-        chooser = ParentChooser(parent=parent, min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+        chooser = ParentChooser(parent=parent, free_space=free,
+                                min_size=Size("1 MiB"), max_size=Size("1 GiB"),
                                 reserved_size=Size(0), selected=True, parent_selectable=True,
                                 size_selectable=True)
 
@@ -826,8 +830,10 @@ class ParentChooserTest(unittest.TestCase):
         """ Test chaning size selection """
         parent = MagicMock()
         parent.configure_mock(name="vda")
+        free = MagicMock()
 
-        chooser = ParentChooser(parent=parent, min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+        chooser = ParentChooser(parent=parent, free_space=free,
+                                min_size=Size("1 MiB"), max_size=Size("1 GiB"),
                                 reserved_size=Size(0), selected=True, parent_selectable=False,
                                 size_selectable=True)
 
@@ -842,8 +848,10 @@ class ParentChooserTest(unittest.TestCase):
         """ Test setting limits (min/max size) """
         parent = MagicMock()
         parent.configure_mock(name="vda")
+        free = MagicMock()
 
-        chooser = ParentChooser(parent=parent, min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+        chooser = ParentChooser(parent=parent, free_space=free,
+                                min_size=Size("1 MiB"), max_size=Size("1 GiB"),
                                 reserved_size=Size(0), selected=True, parent_selectable=False,
                                 size_selectable=True)
 
@@ -877,8 +885,10 @@ class ParentChooserTest(unittest.TestCase):
         """ Test connecting signals and signal handling """
         parent = MagicMock()
         parent.configure_mock(name="vda")
+        free = MagicMock()
 
-        chooser = ParentChooser(parent=parent, min_size=Size("1 MiB"), max_size=Size("1 GiB"),
+        chooser = ParentChooser(parent=parent, free_space=free,
+                                min_size=Size("1 MiB"), max_size=Size("1 GiB"),
                                 reserved_size=Size(0), selected=True, parent_selectable=True,
                                 size_selectable=True)
 


### PR DESCRIPTION
Blivet allows specifying "weight" when adding a partition. Heavier
partitions are added first. Without setting proper weight when
adding a partition in blivet-gui, partitions are actually added
in reverse order.