### PR TITLE
Fix reusing LUKS devices in Anaconda (#1462071)

### DIFF
--- a/blivetgui/blivet_utils.py
+++ b/blivetgui/blivet_utils.py
@@ -1271,6 +1271,9 @@ class BlivetUtils(object):
             return False
 
         else:
+            # save passphrase for future use (in Anaconda only)
+            blivet_device.original_format.passphrase = passphrase
+            self.storage.save_passphrase(blivet_device)
             self.storage.devicetree.populate()
             return True
 


### PR DESCRIPTION
We need to save the passpharase so Anaconda can open the LUKS
device again.