### PR TITLE
Split blivet-gui package into "blivet-gui" and "blivet-gui-runtime"

### DIFF
--- a/blivet-gui.spec
+++ b/blivet-gui.spec
@@ -6,11 +6,24 @@ Source0: http://github.com/rhinstaller/blivet-gui/releases/download/%{version}/%
 License: GPLv2+
 Group: Applications/System
 BuildArch: noarch
-BuildRequires: python3-devel
+URL: http://github.com/rhinstaller/blivet-gui
+
 BuildRequires: desktop-file-utils
+BuildRequires: libappstream-glib
+
+Requires: blivet-gui-runtime = %{version}-%{release}
+
+%description
+Graphical (GTK) tool for manipulation and configuration of data storage
+(disks, LVMs, RAIDs) based on blivet library.
+
+%package -n blivet-gui-runtime
+Summary: blivet-gui runtime
+
+BuildRequires: python3-devel
 BuildRequires: gettext >= 0.18.3
 BuildRequires: python-setuptools
-BuildRequires: libappstream-glib
+
 Requires: python3
 Requires: python3-gobject
 Requires: gettext
@@ -20,11 +33,10 @@ Requires: PolicyKit-authentication-agent
 Requires: python3-pid
 Requires: libreport
 Requires: adwaita-icon-theme
-URL: http://github.com/rhinstaller/blivet-gui
 
-%description
-Graphical (GTK) tool for manipulation and configuration of data storage
-(disks, LVMs, RAIDs) based on blivet library.
+%description -n blivet-gui-runtime
+This package provides a blivet-gui runtime for applications that want to use
+blivet-gui without actually installing the application itself.
 
 %prep
 %setup -q
@@ -54,13 +66,15 @@ fi
 %posttrans
 /usr/bin/gtk-update-icon-cache %{_datadir}/icons/hicolor &>/dev/null || :
 
-%files -f %{name}.lang
+%files -n blivet-gui
+%{_datadir}/applications/blivet-gui.desktop
+%{_datadir}/appdata/blivet-gui.appdata.xml
+
+%files -n blivet-gui-runtime -f %{name}.lang
 %{_mandir}/man1/blivet-gui.1*
 %{python3_sitelib}/*
-%{_datadir}/applications/blivet-gui.desktop
 %{_datadir}/polkit-1/actions/org.fedoraproject.pkexec.blivet-gui.policy
 %{_datadir}/icons/hicolor/*/apps/blivet-gui.png
-%{_datadir}/appdata/blivet-gui.appdata.xml
 %{_datadir}/blivet-gui
 %{_bindir}/blivet-gui
 %{_bindir}/blivet-gui-daemon


### PR DESCRIPTION
Anaconda now depends on blivet-gui, but Fedora Workstation group
doesn't want blivet-gui to be on the installed system. And because
Anaconda can't remove packages after installing from a LiveCD, we
need to split blivet-gui package into a "-runtime" package that
contains all the code and "blivet-gui" package that contains
only the desktop file and appdata (and depends on the "-runtime"
package).

Resolves: rhbz#1449752